### PR TITLE
Implement embodiment helpers for all bone modules

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -3,7 +3,9 @@
 
 This module defines :class:`BoneSpec`, the lightweight container used by all
 bone modules. The class now includes an ``embodiment`` attribute and helpers to
-manage context-aware material data as outlined in ``AGENTS.md``.
+manage context-aware material data as outlined in ``AGENTS.md``.  Allowed
+embodiment states are ``"virtual"``, ``"digital"``, ``"metaphysical"``, and
+``"physical"`` (or any user-defined extension).
 """
 
 from dataclasses import dataclass, field

--- a/skeleton/bones/bone_c1.py
+++ b/skeleton/bones/bone_c1.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C1',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_c2.py
+++ b/skeleton/bones/bone_c2.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C2',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_c3.py
+++ b/skeleton/bones/bone_c3.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C3',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_c4.py
+++ b/skeleton/bones/bone_c4.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C4',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_c5.py
+++ b/skeleton/bones/bone_c5.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C5',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_c6.py
+++ b/skeleton/bones/bone_c6.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C6',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_c7.py
+++ b/skeleton/bones/bone_c7.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_C7',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_calcaneus_l.py
+++ b/skeleton/bones/bone_calcaneus_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CALCANEUS_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_calcaneus_r.py
+++ b/skeleton/bones/bone_calcaneus_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CALCANEUS_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_capitate_l.py
+++ b/skeleton/bones/bone_capitate_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CAPITATE_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_capitate_r.py
+++ b/skeleton/bones/bone_capitate_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CAPITATE_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_clavicle_l.py
+++ b/skeleton/bones/bone_clavicle_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CLAVICLE_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 14.0, 'width_cm': 1.0, 'thickness_cm': 1.0},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_clavicle_r.py
+++ b/skeleton/bones/bone_clavicle_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CLAVICLE_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 14.0, 'width_cm': 1.0, 'thickness_cm': 1.0},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_coccyx.py
+++ b/skeleton/bones/bone_coccyx.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_COCCYX',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_cuboid_l.py
+++ b/skeleton/bones/bone_cuboid_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CUBOID_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_cuboid_r.py
+++ b/skeleton/bones/bone_cuboid_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_CUBOID_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_ethmoid.py
+++ b/skeleton/bones/bone_ethmoid.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_ETHMOID',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 5.0, 'width_cm': 5.0, 'thickness_cm': 0.4},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_femur_l.py
+++ b/skeleton/bones/bone_femur_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_FEMUR_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 48.0, 'width_cm': 2.8, 'thickness_cm': 2.8},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_femur_r.py
+++ b/skeleton/bones/bone_femur_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_FEMUR_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 48.0, 'width_cm': 2.8, 'thickness_cm': 2.8},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_fibula_l.py
+++ b/skeleton/bones/bone_fibula_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_FIBULA_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 40.0, 'width_cm': 1.5, 'thickness_cm': 1.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_fibula_r.py
+++ b/skeleton/bones/bone_fibula_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_FIBULA_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 40.0, 'width_cm': 1.5, 'thickness_cm': 1.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_frontal.py
+++ b/skeleton/bones/bone_frontal.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = 'metopic suture persistence',
     unique_id = 'BONE_FRONTAL',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 13.5, 'width_cm': 14.5, 'thickness_cm': 0.6},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_hamate_l.py
+++ b/skeleton/bones/bone_hamate_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HAMATE_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_hamate_r.py
+++ b/skeleton/bones/bone_hamate_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HAMATE_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_hip_l.py
+++ b/skeleton/bones/bone_hip_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HIP_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_hip_r.py
+++ b/skeleton/bones/bone_hip_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HIP_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_humerus_l.py
+++ b/skeleton/bones/bone_humerus_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HUMERUS_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 35.0, 'width_cm': 2.5, 'thickness_cm': 2.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_humerus_r.py
+++ b/skeleton/bones/bone_humerus_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HUMERUS_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 35.0, 'width_cm': 2.5, 'thickness_cm': 2.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_hyoid.py
+++ b/skeleton/bones/bone_hyoid.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_HYOID',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 2.5, 'width_cm': 3.5, 'thickness_cm': 1.0},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_incus_l.py
+++ b/skeleton/bones/bone_incus_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_INCUS_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 0.8, 'width_cm': 0.4, 'thickness_cm': 0.3},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_incus_r.py
+++ b/skeleton/bones/bone_incus_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_INCUS_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 0.8, 'width_cm': 0.4, 'thickness_cm': 0.3},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_intermediate_cuneiform_l.py
+++ b/skeleton/bones/bone_intermediate_cuneiform_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_INTERMEDIATE_CUNEIFORM_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_intermediate_cuneiform_r.py
+++ b/skeleton/bones/bone_intermediate_cuneiform_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_INTERMEDIATE_CUNEIFORM_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_l1.py
+++ b/skeleton/bones/bone_l1.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_L1',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_l2.py
+++ b/skeleton/bones/bone_l2.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_L2',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_l3.py
+++ b/skeleton/bones/bone_l3.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_L3',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_l4.py
+++ b/skeleton/bones/bone_l4.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_L4',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_l5.py
+++ b/skeleton/bones/bone_l5.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_L5',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_lateral_cuneiform_l.py
+++ b/skeleton/bones/bone_lateral_cuneiform_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_LATERAL_CUNEIFORM_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_lateral_cuneiform_r.py
+++ b/skeleton/bones/bone_lateral_cuneiform_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_LATERAL_CUNEIFORM_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_lunate_l.py
+++ b/skeleton/bones/bone_lunate_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_LUNATE_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_lunate_r.py
+++ b/skeleton/bones/bone_lunate_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_LUNATE_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_malleus_l.py
+++ b/skeleton/bones/bone_malleus_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MALLEUS_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 0.8, 'width_cm': 0.4, 'thickness_cm': 0.3},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_malleus_r.py
+++ b/skeleton/bones/bone_malleus_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MALLEUS_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 0.8, 'width_cm': 0.4, 'thickness_cm': 0.3},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mandible.py
+++ b/skeleton/bones/bone_mandible.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MANDIBLE',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 17.0, 'width_cm': 12.0, 'thickness_cm': 1.0},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_medial_cuneiform_l.py
+++ b/skeleton/bones/bone_medial_cuneiform_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MEDIAL_CUNEIFORM_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_medial_cuneiform_r.py
+++ b/skeleton/bones/bone_medial_cuneiform_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MEDIAL_CUNEIFORM_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta1_l.py
+++ b/skeleton/bones/bone_meta1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta1_r.py
+++ b/skeleton/bones/bone_meta1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta2_l.py
+++ b/skeleton/bones/bone_meta2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta2_r.py
+++ b/skeleton/bones/bone_meta2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta3_l.py
+++ b/skeleton/bones/bone_meta3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta3_r.py
+++ b/skeleton/bones/bone_meta3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta4_l.py
+++ b/skeleton/bones/bone_meta4_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META4_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta4_r.py
+++ b/skeleton/bones/bone_meta4_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META4_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta5_l.py
+++ b/skeleton/bones/bone_meta5_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META5_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_meta5_r.py
+++ b/skeleton/bones/bone_meta5_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_META5_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt1_l.py
+++ b/skeleton/bones/bone_mt1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt1_r.py
+++ b/skeleton/bones/bone_mt1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt2_l.py
+++ b/skeleton/bones/bone_mt2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt2_r.py
+++ b/skeleton/bones/bone_mt2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt3_l.py
+++ b/skeleton/bones/bone_mt3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt3_r.py
+++ b/skeleton/bones/bone_mt3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt4_l.py
+++ b/skeleton/bones/bone_mt4_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT4_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt4_r.py
+++ b/skeleton/bones/bone_mt4_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT4_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt5_l.py
+++ b/skeleton/bones/bone_mt5_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT5_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_mt5_r.py
+++ b/skeleton/bones/bone_mt5_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_MT5_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_navicular_l.py
+++ b/skeleton/bones/bone_navicular_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_NAVICULAR_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_navicular_r.py
+++ b/skeleton/bones/bone_navicular_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_NAVICULAR_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_occipital.py
+++ b/skeleton/bones/bone_occipital.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_OCCIPITAL',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 12.0, 'width_cm': 11.0, 'thickness_cm': 0.6},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_par_l.py
+++ b/skeleton/bones/bone_par_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PAR_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 14.0, 'width_cm': 10.0, 'thickness_cm': 0.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_par_r.py
+++ b/skeleton/bones/bone_par_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PAR_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 14.0, 'width_cm': 10.0, 'thickness_cm': 0.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_patella_l.py
+++ b/skeleton/bones/bone_patella_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PATELLA_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_patella_r.py
+++ b/skeleton/bones/bone_patella_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PATELLA_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_1_1_l.py
+++ b/skeleton/bones/bone_phal_1_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_1_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_1_1_r.py
+++ b/skeleton/bones/bone_phal_1_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_1_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_1_2_l.py
+++ b/skeleton/bones/bone_phal_1_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_1_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_1_2_r.py
+++ b/skeleton/bones/bone_phal_1_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_1_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_2_1_l.py
+++ b/skeleton/bones/bone_phal_2_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_2_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_2_1_r.py
+++ b/skeleton/bones/bone_phal_2_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_2_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_2_2_l.py
+++ b/skeleton/bones/bone_phal_2_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_2_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_2_2_r.py
+++ b/skeleton/bones/bone_phal_2_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_2_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_2_3_l.py
+++ b/skeleton/bones/bone_phal_2_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_2_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_2_3_r.py
+++ b/skeleton/bones/bone_phal_2_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_2_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_3_1_l.py
+++ b/skeleton/bones/bone_phal_3_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_3_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_3_1_r.py
+++ b/skeleton/bones/bone_phal_3_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_3_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_3_2_l.py
+++ b/skeleton/bones/bone_phal_3_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_3_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_3_2_r.py
+++ b/skeleton/bones/bone_phal_3_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_3_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_3_3_l.py
+++ b/skeleton/bones/bone_phal_3_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_3_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_3_3_r.py
+++ b/skeleton/bones/bone_phal_3_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_3_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_4_1_l.py
+++ b/skeleton/bones/bone_phal_4_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_4_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_4_1_r.py
+++ b/skeleton/bones/bone_phal_4_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_4_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_4_2_l.py
+++ b/skeleton/bones/bone_phal_4_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_4_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_4_2_r.py
+++ b/skeleton/bones/bone_phal_4_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_4_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_4_3_l.py
+++ b/skeleton/bones/bone_phal_4_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_4_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_4_3_r.py
+++ b/skeleton/bones/bone_phal_4_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_4_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_5_1_l.py
+++ b/skeleton/bones/bone_phal_5_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_5_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_5_1_r.py
+++ b/skeleton/bones/bone_phal_5_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_5_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_5_2_l.py
+++ b/skeleton/bones/bone_phal_5_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_5_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_5_2_r.py
+++ b/skeleton/bones/bone_phal_5_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_5_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_5_3_l.py
+++ b/skeleton/bones/bone_phal_5_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_5_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_phal_5_3_r.py
+++ b/skeleton/bones/bone_phal_5_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PHAL_5_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_pisiform_l.py
+++ b/skeleton/bones/bone_pisiform_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PISIFORM_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_pisiform_r.py
+++ b/skeleton/bones/bone_pisiform_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_PISIFORM_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_radius_l.py
+++ b/skeleton/bones/bone_radius_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RADIUS_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 24.0, 'width_cm': 1.5, 'thickness_cm': 1.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_radius_r.py
+++ b/skeleton/bones/bone_radius_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RADIUS_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 24.0, 'width_cm': 1.5, 'thickness_cm': 1.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib10_l.py
+++ b/skeleton/bones/bone_rib10_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB10_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib10_r.py
+++ b/skeleton/bones/bone_rib10_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB10_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib11_l.py
+++ b/skeleton/bones/bone_rib11_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB11_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib11_r.py
+++ b/skeleton/bones/bone_rib11_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB11_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib12_l.py
+++ b/skeleton/bones/bone_rib12_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB12_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib12_r.py
+++ b/skeleton/bones/bone_rib12_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB12_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib1_l.py
+++ b/skeleton/bones/bone_rib1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib1_r.py
+++ b/skeleton/bones/bone_rib1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib2_l.py
+++ b/skeleton/bones/bone_rib2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib2_r.py
+++ b/skeleton/bones/bone_rib2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib3_l.py
+++ b/skeleton/bones/bone_rib3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib3_r.py
+++ b/skeleton/bones/bone_rib3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib4_l.py
+++ b/skeleton/bones/bone_rib4_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB4_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib4_r.py
+++ b/skeleton/bones/bone_rib4_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB4_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib5_l.py
+++ b/skeleton/bones/bone_rib5_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB5_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib5_r.py
+++ b/skeleton/bones/bone_rib5_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB5_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib6_l.py
+++ b/skeleton/bones/bone_rib6_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB6_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib6_r.py
+++ b/skeleton/bones/bone_rib6_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB6_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib7_l.py
+++ b/skeleton/bones/bone_rib7_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB7_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib7_r.py
+++ b/skeleton/bones/bone_rib7_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB7_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib8_l.py
+++ b/skeleton/bones/bone_rib8_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB8_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib8_r.py
+++ b/skeleton/bones/bone_rib8_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB8_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib9_l.py
+++ b/skeleton/bones/bone_rib9_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB9_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_rib9_r.py
+++ b/skeleton/bones/bone_rib9_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_RIB9_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_sacrum.py
+++ b/skeleton/bones/bone_sacrum.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_SACRUM',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_scaphoid_l.py
+++ b/skeleton/bones/bone_scaphoid_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_SCAPHOID_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_scaphoid_r.py
+++ b/skeleton/bones/bone_scaphoid_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_SCAPHOID_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_scapula_l.py
+++ b/skeleton/bones/bone_scapula_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_SCAPULA_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_scapula_r.py
+++ b/skeleton/bones/bone_scapula_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_SCAPULA_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_sphenoid.py
+++ b/skeleton/bones/bone_sphenoid.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_SPHENOID',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 6.0, 'width_cm': 8.0, 'thickness_cm': 0.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_stapes_l.py
+++ b/skeleton/bones/bone_stapes_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_STAPES_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 0.8, 'width_cm': 0.4, 'thickness_cm': 0.3},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_stapes_r.py
+++ b/skeleton/bones/bone_stapes_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_STAPES_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 0.8, 'width_cm': 0.4, 'thickness_cm': 0.3},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_sternum.py
+++ b/skeleton/bones/bone_sternum.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_STERNUM',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t1.py
+++ b/skeleton/bones/bone_t1.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T1',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t10.py
+++ b/skeleton/bones/bone_t10.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T10',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t11.py
+++ b/skeleton/bones/bone_t11.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T11',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t12.py
+++ b/skeleton/bones/bone_t12.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T12',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t2.py
+++ b/skeleton/bones/bone_t2.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T2',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t3.py
+++ b/skeleton/bones/bone_t3.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T3',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t4.py
+++ b/skeleton/bones/bone_t4.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T4',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t5.py
+++ b/skeleton/bones/bone_t5.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T5',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t6.py
+++ b/skeleton/bones/bone_t6.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T6',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t7.py
+++ b/skeleton/bones/bone_t7.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T7',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t8.py
+++ b/skeleton/bones/bone_t8.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T8',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t9.py
+++ b/skeleton/bones/bone_t9.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T9',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_1_1_l.py
+++ b/skeleton/bones/bone_t_phal_1_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_1_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_1_1_r.py
+++ b/skeleton/bones/bone_t_phal_1_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_1_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_1_2_l.py
+++ b/skeleton/bones/bone_t_phal_1_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_1_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_1_2_r.py
+++ b/skeleton/bones/bone_t_phal_1_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_1_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_2_1_l.py
+++ b/skeleton/bones/bone_t_phal_2_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_2_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_2_1_r.py
+++ b/skeleton/bones/bone_t_phal_2_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_2_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_2_2_l.py
+++ b/skeleton/bones/bone_t_phal_2_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_2_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_2_2_r.py
+++ b/skeleton/bones/bone_t_phal_2_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_2_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_2_3_l.py
+++ b/skeleton/bones/bone_t_phal_2_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_2_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_2_3_r.py
+++ b/skeleton/bones/bone_t_phal_2_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_2_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_3_1_l.py
+++ b/skeleton/bones/bone_t_phal_3_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_3_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_3_1_r.py
+++ b/skeleton/bones/bone_t_phal_3_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_3_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_3_2_l.py
+++ b/skeleton/bones/bone_t_phal_3_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_3_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_3_2_r.py
+++ b/skeleton/bones/bone_t_phal_3_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_3_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_3_3_l.py
+++ b/skeleton/bones/bone_t_phal_3_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_3_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_3_3_r.py
+++ b/skeleton/bones/bone_t_phal_3_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_3_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_4_1_l.py
+++ b/skeleton/bones/bone_t_phal_4_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_4_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_4_1_r.py
+++ b/skeleton/bones/bone_t_phal_4_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_4_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_4_2_l.py
+++ b/skeleton/bones/bone_t_phal_4_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_4_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_4_2_r.py
+++ b/skeleton/bones/bone_t_phal_4_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_4_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_4_3_l.py
+++ b/skeleton/bones/bone_t_phal_4_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_4_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_4_3_r.py
+++ b/skeleton/bones/bone_t_phal_4_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_4_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_5_1_l.py
+++ b/skeleton/bones/bone_t_phal_5_1_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_5_1_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_5_1_r.py
+++ b/skeleton/bones/bone_t_phal_5_1_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_5_1_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_5_2_l.py
+++ b/skeleton/bones/bone_t_phal_5_2_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_5_2_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_5_2_r.py
+++ b/skeleton/bones/bone_t_phal_5_2_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_5_2_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_5_3_l.py
+++ b/skeleton/bones/bone_t_phal_5_3_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_5_3_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_t_phal_5_3_r.py
+++ b/skeleton/bones/bone_t_phal_5_3_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_T_PHAL_5_3_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_talus_l.py
+++ b/skeleton/bones/bone_talus_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TALUS_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_talus_r.py
+++ b/skeleton/bones/bone_talus_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TALUS_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_temp_l.py
+++ b/skeleton/bones/bone_temp_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TEMP_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 7.0, 'width_cm': 7.0, 'thickness_cm': 0.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_temp_r.py
+++ b/skeleton/bones/bone_temp_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TEMP_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 7.0, 'width_cm': 7.0, 'thickness_cm': 0.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_tibia_l.py
+++ b/skeleton/bones/bone_tibia_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TIBIA_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 40.0, 'width_cm': 2.5, 'thickness_cm': 2.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_tibia_r.py
+++ b/skeleton/bones/bone_tibia_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TIBIA_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 40.0, 'width_cm': 2.5, 'thickness_cm': 2.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_trapezium_l.py
+++ b/skeleton/bones/bone_trapezium_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TRAPEZIUM_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_trapezium_r.py
+++ b/skeleton/bones/bone_trapezium_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TRAPEZIUM_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_trapezoid_l.py
+++ b/skeleton/bones/bone_trapezoid_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TRAPEZOID_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_trapezoid_r.py
+++ b/skeleton/bones/bone_trapezoid_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TRAPEZOID_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_triquetrum_l.py
+++ b/skeleton/bones/bone_triquetrum_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TRIQUETRUM_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_triquetrum_r.py
+++ b/skeleton/bones/bone_triquetrum_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_TRIQUETRUM_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_ulna_l.py
+++ b/skeleton/bones/bone_ulna_l.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_ULNA_L',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 25.0, 'width_cm': 1.5, 'thickness_cm': 1.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()

--- a/skeleton/bones/bone_ulna_r.py
+++ b/skeleton/bones/bone_ulna_r.py
@@ -13,5 +13,15 @@ bone = BoneSpec(
     variations = '',
     unique_id = 'BONE_ULNA_R',
     visual_reference = None,
+    embodiment = "virtual",
     geometry = {'shape': 'box', 'length_cm': 25.0, 'width_cm': 1.5, 'thickness_cm': 1.5},
 )
+
+
+def set_embodiment(state, material=None):
+    """Update embodiment for this bone."""
+    bone.set_embodiment(state, material)
+
+def self_state():
+    """Return the bone's current state."""
+    return bone.self_state()


### PR DESCRIPTION
## Summary
- note valid embodiment states in `BoneSpec` docs
- expose default embodiment and runtime helpers in all bone modules

## Testing
- `python assemble_skeleton.py > /tmp/skeleton.json`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685852bf4c608324b10a374a4da25861