### PR TITLE
Implement entanglement protocol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*/__pycache__/
+*.pyc

--- a/assemble_skeleton.py
+++ b/assemble_skeleton.py
@@ -1,7 +1,13 @@
 from skeleton import load_bones
+from skeleton.field import SkeletonField
 import json
 
 if __name__ == "__main__":
     bones = load_bones()
-    data = {b.unique_id: b.__dict__ for b in bones}
+    field = SkeletonField(bones)
+    data = {
+        "bones": {b.unique_id: b.self_state() for b in bones},
+        "health": field.health(),
+        "faults": field.faults(),
+    }
     print(json.dumps(data, indent=2))

--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -8,8 +8,25 @@ embodiment states are ``"virtual"``, ``"digital"``, ``"metaphysical"``, and
 ``"physical"`` (or any user-defined extension).
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
+
+
+class MarrowAgent:
+    """Bioelectric regulator for a bone domain."""
+
+    def __init__(self, voltage: float = 0.0, charge: float = 0.0) -> None:
+        self.voltage = voltage
+        self.charge = charge
+
+    def regulate(self, voltage_in: float, signal_type: str = "EMG") -> float:
+        """Return regulated voltage while updating charge."""
+        self.voltage = 0.5 * (self.voltage + voltage_in)
+        if signal_type in {"EMG", "EKG"}:
+            self.charge += self.voltage * 0.01
+        return self.voltage
 
 @dataclass
 class BoneSpec:
@@ -28,51 +45,153 @@ class BoneSpec:
     geometry: Dict[str, float] = field(default_factory=dict)
     embodiment: str = "virtual"
     material_attributes: Optional[Dict[str, float]] = None
+    domain_id: Optional[str] = None
+    ground_state: bool = False
+    voltage_potential: float = 0.0
+    entanglement_links: List[str] = field(default_factory=list)
+    marrow: MarrowAgent = field(default_factory=MarrowAgent)
+    position: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    orientation: Tuple[float, float, float, float] = (1.0, 0.0, 0.0, 0.0)
+    load: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    torsion: Tuple[float, float, float] = (0.0, 0.0, 0.0)
+    state_faults: List[str] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         """Initialize dynamic docstring for this bone object."""
         self.__doc__ = f"{self.name} bone agent (default embodiment: {self.embodiment})."
+        if self.domain_id is None:
+            self.domain_id = self.unique_id
+        self.state_faults = []
 
     def mass_kg(self) -> Optional[float]:
-        if self.embodiment != "physical":
-            raise ValueError(
-                f"{self.name} is not embodied physically—mass undefined in state '{self.embodiment}'."
-            )
-        vol = self.volume_cm3()
-        if vol is None:
+        try:
+            if self.embodiment != "physical":
+                raise ValueError(
+                    f"{self.name} is not embodied physically—mass undefined in state '{self.embodiment}'."
+                )
+            vol = self.volume_cm3()
+            if vol is None:
+                return None
+            return self.material["density"] * vol / 1e6
+        except Exception as e:
+            self.state_faults.append(f"Mass error: {e}")
             return None
-        return self.material["density"] * vol / 1e6
 
     def volume_cm3(self) -> Optional[float]:
-        l = self.dimensions.get("length_cm")
-        w = self.dimensions.get("width_cm")
-        t = self.dimensions.get("thickness_cm")
-        if None not in (l, w, t):
-            return l * w * t
-        return None
+        try:
+            l = self.dimensions.get("length_cm")
+            w = self.dimensions.get("width_cm")
+            t = self.dimensions.get("thickness_cm")
+            if None not in (l, w, t):
+                return l * w * t
+            return None
+        except Exception as e:
+            self.state_faults.append(f"Volume error: {e}")
+            return None
 
     def set_material(self, name: str, density: float) -> None:
-        self.material["name"] = name
-        self.material["density"] = density
+        try:
+            self.material["name"] = name
+            self.material["density"] = float(density)
+        except Exception as e:
+            self.state_faults.append(f"Material error: {e}")
 
     def set_embodiment(self, state: str, material: Optional[Dict[str, float]] = None) -> None:
         """Update the embodiment state and material context."""
-        self.embodiment = state
-        if state == "physical":
-            if material is not None:
-                self.material.update(material)
-            self.material_attributes = self.material.copy()
-        else:
-            self.material_attributes = None
+        try:
+            self.embodiment = state
+            if state == "physical":
+                if material is not None:
+                    self.material.update(material)
+                self.material_attributes = self.material.copy()
+            else:
+                self.material_attributes = None
+        except Exception as e:
+            self.state_faults.append(f"Embodiment error: {e}")
 
     def self_state(self) -> Dict[str, object]:
         """Return a dict summarizing the bone's current state."""
+        return self.current_state()
+
+    def current_state(self) -> Dict[str, object]:
         return {
             "bone": self.name,
             "uid": self.unique_id,
+            "domain_id": self.domain_id,
             "embodiment": self.embodiment,
             "material": self.material.get("name") if self.material_attributes else "non-tangible",
             "material_attributes": self.material_attributes if self.material_attributes else "N/A",
             "context": "simulated" if self.embodiment in ["virtual", "digital"] else "manifested",
             "module": __file__,
+            "voltage": self.voltage_potential,
+            "links": list(self.entanglement_links),
+            "position": self.position,
+            "orientation": self.orientation,
+            "load": self.load,
+            "torsion": self.torsion,
+            "faults": list(self.state_faults),
         }
+
+    def update_state(
+        self,
+        position: Optional[Tuple[float, float, float]] = None,
+        orientation: Optional[Tuple[float, float, float, float]] = None,
+        load: Optional[Tuple[float, float, float]] = None,
+        torsion: Optional[Tuple[float, float, float]] = None,
+    ) -> None:
+        try:
+            if position is not None:
+                self.position = position
+            if orientation is not None:
+                self.orientation = orientation
+            if load is not None:
+                self.load = load
+            if torsion is not None:
+                self.torsion = torsion
+        except Exception as e:
+            self.state_faults.append(f"Update error: {e}")
+
+    def is_healthy(self) -> bool:
+        return len(self.state_faults) == 0
+
+    def clear_faults(self) -> None:
+        self.state_faults = []
+
+    def report_faults(self) -> List[str]:
+        return list(self.state_faults)
+
+    def notify_fault(self) -> None:
+        message = self.state_faults[-1] if self.state_faults else "fault"
+        for link_id in self.entanglement_links:
+            pass  # In a full implementation this would propagate to neighbor bones
+
+    def receive_fault_notice(self, from_domain: str, message: str) -> None:
+        self.state_faults.append(f"Neighbor {from_domain} fault: {message}")
+
+    def entangle(self, other_bone: "BoneSpec") -> None:
+        """Create a bidirectional entanglement link with another bone."""
+        if other_bone.domain_id not in self.entanglement_links:
+            self.entanglement_links.append(other_bone.domain_id)
+        if self.domain_id not in other_bone.entanglement_links:
+            other_bone.entanglement_links.append(self.domain_id)
+
+    def receive_signal(self, signal: Dict[str, float], from_domain: str) -> float:
+        """Accept a signal from another domain and regulate voltage."""
+        try:
+            voltage = signal.get("voltage", 0.0)
+            stype = signal.get("type", "EMG")
+            self.voltage_potential = self.marrow.regulate(voltage, stype)
+            return self.voltage_potential
+        except Exception as e:
+            self.state_faults.append(f"Receive error from {from_domain}: {e}")
+            return self.voltage_potential
+
+    def emit_signal(self, to_bone: "BoneSpec", signal: Dict[str, float]) -> float:
+        """Emit a signal to another entangled bone."""
+        try:
+            if to_bone.domain_id not in self.entanglement_links:
+                raise ValueError(f"{to_bone.domain_id} not entangled with {self.domain_id}")
+            return to_bone.receive_signal(signal, self.domain_id)
+        except Exception as e:
+            self.state_faults.append(f"Signal error: {e}")
+            return 0.0

--- a/skeleton/bones/__init__.py
+++ b/skeleton/bones/__init__.py
@@ -6,10 +6,19 @@ from typing import List
 from ..base import BoneSpec
 
 def load_bones() -> List[BoneSpec]:
-    bones = []
+    bones: List[BoneSpec] = []
     for file in Path(__file__).parent.glob('*.py'):
         if file.name == '__init__.py':
             continue
         module = import_module(f'skeleton.bones.{file.stem}')
         bones.append(module.bone)
+
+    # establish entanglements based on articulations
+    name_map = {b.name: b for b in bones}
+    for bone in bones:
+        for art in bone.articulations:
+            other = name_map.get(art.get('bone'))
+            if other and other is not bone:
+                bone.entangle(other)
+
     return bones

--- a/skeleton/field.py
+++ b/skeleton/field.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Dict, List
+
+from .base import BoneSpec
+
+class SkeletonField:
+    """Network field managing bioelectric signal propagation."""
+
+    def __init__(self, bones: List[BoneSpec]):
+        self.bones: Dict[str, BoneSpec] = {b.domain_id: b for b in bones}
+
+    def broadcast(self, voltage: float, signal_type: str = "EMG") -> None:
+        signal = {"voltage": voltage, "type": signal_type}
+        for bone in self.bones.values():
+            bone.receive_signal(signal, "FIELD")
+
+    def propagate(self, from_domain: str, signal: Dict[str, float]) -> None:
+        origin = self.bones.get(from_domain)
+        if not origin:
+            return
+        visited = set()
+
+        def _prop(b: BoneSpec):
+            if b.domain_id in visited:
+                return
+            visited.add(b.domain_id)
+            for link_id in b.entanglement_links:
+                other = self.bones.get(link_id)
+                if other:
+                    other.receive_signal(signal, b.domain_id)
+                    _prop(other)
+
+        _prop(origin)
+
+    def status(self) -> Dict[str, Dict[str, object]]:
+        return {d: {"voltage": b.voltage_potential, "links": list(b.entanglement_links)} for d, b in self.bones.items()}
+
+    def health(self) -> Dict[str, bool]:
+        """Return health status for each bone."""
+        return {d: b.is_healthy() for d, b in self.bones.items()}
+
+    def faults(self) -> Dict[str, List[str]]:
+        """Return fault lists per bone."""
+        return {d: b.report_faults() for d, b in self.bones.items() if not b.is_healthy()}

--- a/tests/test_bone_state.py
+++ b/tests/test_bone_state.py
@@ -1,0 +1,35 @@
+import unittest
+from skeleton.base import BoneSpec
+
+class BoneStateTest(unittest.TestCase):
+    def setUp(self):
+        self.bone = BoneSpec(
+            name='Test',
+            bone_type='long',
+            location={},
+            articulations=[],
+            dimensions={'length_cm': 10.0, 'width_cm': 2.0, 'thickness_cm': 1.0},
+            function=[],
+            notable_features=[],
+            developmental_notes='',
+            variations='',
+            unique_id='TEST1'
+        )
+
+    def test_fault_on_mass_virtual(self):
+        self.assertIsNone(self.bone.mass_kg())
+        self.assertFalse(self.bone.is_healthy())
+        self.assertTrue(any('Mass error' in f for f in self.bone.state_faults))
+
+    def test_update_and_clear_faults(self):
+        self.bone.clear_faults()
+        self.bone.set_embodiment('physical', {'density': 1000})
+        mass = self.bone.mass_kg()
+        self.assertIsNotNone(mass)
+        self.bone.update_state(position=(1,2,3), load=(10,0,0))
+        state = self.bone.current_state()
+        self.assertEqual(state['position'], (1,2,3))
+        self.assertTrue(self.bone.is_healthy())
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `MarrowAgent` and bionic entanglement attributes in `BoneSpec`
- connect bones based on articulations when loading
- provide `SkeletonField` for network-wide signal propagation
- include bone state in assembly output
- add resilience fields and fault tracking to `BoneSpec`
- expose health and fault summaries in `SkeletonField`
- add unit tests for new state logic

## Testing
- `python3 -m py_compile $(git ls-files '*.py') && echo compiled`
- `python3 -m unittest discover -s tests -v`
- `python3 assemble_skeleton.py > /tmp/output.json && tail -n 5 /tmp/output.json`


------
https://chatgpt.com/codex/tasks/task_e_6858c8346e9c832486c07cb2420cb3e7