### PR TITLE
Extend bone network with metaphysical operations

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -17,31 +17,23 @@ from typing import Dict, List, Optional, Tuple
 class MarrowAgent:
     """Bioelectric regulator for a bone domain."""
 
-    def __init__(self, voltage: float = 0.0, charge: float = 0.0) -> None:
+    def __init__(self, voltage: float = 0.0, charge: float = 0.0, energy: float = 1.0) -> None:
         self.voltage = voltage
         self.charge = charge
+        self.energy = energy
 
     def regulate(self, voltage_in: float, signal_type: str = "EMG") -> float:
-        """Return regulated voltage while updating charge."""
+        """Return regulated voltage while updating charge and energy."""
         self.voltage = 0.5 * (self.voltage + voltage_in)
         if signal_type in {"EMG", "EKG"}:
             self.charge += self.voltage * 0.01
+        else:
+            self.charge += self.voltage * 0.005
+        self.energy += self.voltage * 0.01
         return self.voltage
 
-
-class MarrowAgent:
-    """Bioelectric regulator for a bone domain."""
-
-    def __init__(self, voltage: float = 0.0, charge: float = 0.0) -> None:
-        self.voltage = voltage
-        self.charge = charge
-
-    def regulate(self, voltage_in: float, signal_type: str = "EMG") -> float:
-        """Return regulated voltage while updating charge."""
-        self.voltage = 0.5 * (self.voltage + voltage_in)
-        if signal_type in {"EMG", "EKG"}:
-            self.charge += self.voltage * 0.01
-        return self.voltage
+    def audit(self) -> Dict[str, float]:
+        return {"voltage": self.voltage, "charge": self.charge, "energy": self.energy}
 
 @dataclass
 class BoneSpec:
@@ -70,6 +62,7 @@ class BoneSpec:
     load: Tuple[float, float, float] = (0.0, 0.0, 0.0)
     torsion: Tuple[float, float, float] = (0.0, 0.0, 0.0)
     state_faults: List[str] = field(default_factory=list)
+    resonance: List[str] = field(default_factory=list)
 
 
     def __post_init__(self) -> None:
@@ -78,6 +71,7 @@ class BoneSpec:
         if self.domain_id is None:
             self.domain_id = self.unique_id
         self.state_faults = []
+        self.resonance = []
 
 
     def mass_kg(self) -> Optional[float]:
@@ -212,4 +206,22 @@ class BoneSpec:
         except Exception as e:
             self.state_faults.append(f"Signal error: {e}")
             return 0.0
+
+    def transcend(self, intent: Optional[str] = None) -> None:
+        """Increase internal energy and optionally log metaphysical intent."""
+        self.marrow.energy += 1.0
+        if intent:
+            self.resonance.append(intent)
+
+    def invoke(self, field: "SkeletonField", intent: str) -> None:
+        """Propagate a symbolic signal through the field."""
+        signal = {"voltage": self.voltage_potential, "type": intent}
+        field.propagate(self.domain_id, signal)
+
+    def audit(self) -> Dict[str, object]:
+        """Return full state information including marrow audit."""
+        state = self.current_state()
+        state["marrow"] = self.marrow.audit()
+        state["resonance"] = list(self.resonance)
+        return state
 

--- a/skeleton/field.py
+++ b/skeleton/field.py
@@ -33,6 +33,20 @@ class SkeletonField:
 
         _prop(origin)
 
+    def total_voltage(self) -> float:
+        """Return the summed voltage potential of all bones."""
+        return sum(b.voltage_potential for b in self.bones.values())
+
+    def meta_breath(self, word: str) -> None:
+        """Invoke a metaphysical intent across all bones."""
+        for bone in self.bones.values():
+            bone.transcend(intent=word)
+
+    def collapse(self) -> None:
+        """Remove all entanglement links between bones."""
+        for bone in self.bones.values():
+            bone.entanglement_links.clear()
+
     def status(self) -> Dict[str, Dict[str, object]]:
         return {d: {"voltage": b.voltage_potential, "links": list(b.entanglement_links)} for d, b in self.bones.items()}
 

--- a/tests/test_bone_state.py
+++ b/tests/test_bone_state.py
@@ -1,4 +1,9 @@
 import unittest
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
 from skeleton.base import BoneSpec
 
 class BoneStateTest(unittest.TestCase):

--- a/tests/test_meta_field.py
+++ b/tests/test_meta_field.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import unittest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from skeleton.base import BoneSpec
+from skeleton.field import SkeletonField
+
+class FieldMetaTest(unittest.TestCase):
+    def test_meta_breath_and_total_voltage(self):
+        b1 = BoneSpec(name='A', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='', variations='', unique_id='A1')
+        b2 = BoneSpec(name='B', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='', variations='', unique_id='B1')
+        b1.entangle(b2)
+        field = SkeletonField([b1, b2])
+        field.broadcast(5.0)
+        self.assertAlmostEqual(field.total_voltage(), b1.voltage_potential + b2.voltage_potential)
+        field.meta_breath('awaken')
+        self.assertIn('awaken', b1.resonance)
+        self.assertIn('awaken', b2.resonance)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- expand `MarrowAgent` with energy tracking and auditing
- support bone resonance and metaphysical invocation
- add metasystem helpers to `SkeletonField`
- update tests and add `test_meta_field`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858e75e78588324b9176928989b34db