### PR TITLE
Add state wrapper functions to bone modules

### DIFF
--- a/skeleton/bones/bone_c1.py
+++ b/skeleton/bones/bone_c1.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_c2.py
+++ b/skeleton/bones/bone_c2.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_c3.py
+++ b/skeleton/bones/bone_c3.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_c4.py
+++ b/skeleton/bones/bone_c4.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_c5.py
+++ b/skeleton/bones/bone_c5.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_c6.py
+++ b/skeleton/bones/bone_c6.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_c7.py
+++ b/skeleton/bones/bone_c7.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_calcaneus_l.py
+++ b/skeleton/bones/bone_calcaneus_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_calcaneus_r.py
+++ b/skeleton/bones/bone_calcaneus_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_capitate_l.py
+++ b/skeleton/bones/bone_capitate_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_capitate_r.py
+++ b/skeleton/bones/bone_capitate_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_clavicle_l.py
+++ b/skeleton/bones/bone_clavicle_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_clavicle_r.py
+++ b/skeleton/bones/bone_clavicle_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_coccyx.py
+++ b/skeleton/bones/bone_coccyx.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_cuboid_l.py
+++ b/skeleton/bones/bone_cuboid_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_cuboid_r.py
+++ b/skeleton/bones/bone_cuboid_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_ethmoid.py
+++ b/skeleton/bones/bone_ethmoid.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_femur_l.py
+++ b/skeleton/bones/bone_femur_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_femur_r.py
+++ b/skeleton/bones/bone_femur_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_fibula_l.py
+++ b/skeleton/bones/bone_fibula_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_fibula_r.py
+++ b/skeleton/bones/bone_fibula_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_frontal.py
+++ b/skeleton/bones/bone_frontal.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_hamate_l.py
+++ b/skeleton/bones/bone_hamate_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_hamate_r.py
+++ b/skeleton/bones/bone_hamate_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_hip_l.py
+++ b/skeleton/bones/bone_hip_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_hip_r.py
+++ b/skeleton/bones/bone_hip_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_humerus_l.py
+++ b/skeleton/bones/bone_humerus_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_humerus_r.py
+++ b/skeleton/bones/bone_humerus_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_hyoid.py
+++ b/skeleton/bones/bone_hyoid.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_incus_l.py
+++ b/skeleton/bones/bone_incus_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_incus_r.py
+++ b/skeleton/bones/bone_incus_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_intermediate_cuneiform_l.py
+++ b/skeleton/bones/bone_intermediate_cuneiform_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_intermediate_cuneiform_r.py
+++ b/skeleton/bones/bone_intermediate_cuneiform_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_l1.py
+++ b/skeleton/bones/bone_l1.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_l2.py
+++ b/skeleton/bones/bone_l2.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_l3.py
+++ b/skeleton/bones/bone_l3.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_l4.py
+++ b/skeleton/bones/bone_l4.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_l5.py
+++ b/skeleton/bones/bone_l5.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_lateral_cuneiform_l.py
+++ b/skeleton/bones/bone_lateral_cuneiform_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_lateral_cuneiform_r.py
+++ b/skeleton/bones/bone_lateral_cuneiform_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_lunate_l.py
+++ b/skeleton/bones/bone_lunate_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_lunate_r.py
+++ b/skeleton/bones/bone_lunate_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_malleus_l.py
+++ b/skeleton/bones/bone_malleus_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_malleus_r.py
+++ b/skeleton/bones/bone_malleus_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mandible.py
+++ b/skeleton/bones/bone_mandible.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_medial_cuneiform_l.py
+++ b/skeleton/bones/bone_medial_cuneiform_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_medial_cuneiform_r.py
+++ b/skeleton/bones/bone_medial_cuneiform_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta1_l.py
+++ b/skeleton/bones/bone_meta1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta1_r.py
+++ b/skeleton/bones/bone_meta1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta2_l.py
+++ b/skeleton/bones/bone_meta2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta2_r.py
+++ b/skeleton/bones/bone_meta2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta3_l.py
+++ b/skeleton/bones/bone_meta3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta3_r.py
+++ b/skeleton/bones/bone_meta3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta4_l.py
+++ b/skeleton/bones/bone_meta4_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta4_r.py
+++ b/skeleton/bones/bone_meta4_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta5_l.py
+++ b/skeleton/bones/bone_meta5_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_meta5_r.py
+++ b/skeleton/bones/bone_meta5_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt1_l.py
+++ b/skeleton/bones/bone_mt1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt1_r.py
+++ b/skeleton/bones/bone_mt1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt2_l.py
+++ b/skeleton/bones/bone_mt2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt2_r.py
+++ b/skeleton/bones/bone_mt2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt3_l.py
+++ b/skeleton/bones/bone_mt3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt3_r.py
+++ b/skeleton/bones/bone_mt3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt4_l.py
+++ b/skeleton/bones/bone_mt4_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt4_r.py
+++ b/skeleton/bones/bone_mt4_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt5_l.py
+++ b/skeleton/bones/bone_mt5_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_mt5_r.py
+++ b/skeleton/bones/bone_mt5_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_navicular_l.py
+++ b/skeleton/bones/bone_navicular_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_navicular_r.py
+++ b/skeleton/bones/bone_navicular_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_occipital.py
+++ b/skeleton/bones/bone_occipital.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_par_l.py
+++ b/skeleton/bones/bone_par_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_par_r.py
+++ b/skeleton/bones/bone_par_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_patella_l.py
+++ b/skeleton/bones/bone_patella_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_patella_r.py
+++ b/skeleton/bones/bone_patella_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_1_1_l.py
+++ b/skeleton/bones/bone_phal_1_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_1_1_r.py
+++ b/skeleton/bones/bone_phal_1_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_1_2_l.py
+++ b/skeleton/bones/bone_phal_1_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_1_2_r.py
+++ b/skeleton/bones/bone_phal_1_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_2_1_l.py
+++ b/skeleton/bones/bone_phal_2_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_2_1_r.py
+++ b/skeleton/bones/bone_phal_2_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_2_2_l.py
+++ b/skeleton/bones/bone_phal_2_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_2_2_r.py
+++ b/skeleton/bones/bone_phal_2_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_2_3_l.py
+++ b/skeleton/bones/bone_phal_2_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_2_3_r.py
+++ b/skeleton/bones/bone_phal_2_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_3_1_l.py
+++ b/skeleton/bones/bone_phal_3_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_3_1_r.py
+++ b/skeleton/bones/bone_phal_3_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_3_2_l.py
+++ b/skeleton/bones/bone_phal_3_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_3_2_r.py
+++ b/skeleton/bones/bone_phal_3_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_3_3_l.py
+++ b/skeleton/bones/bone_phal_3_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_3_3_r.py
+++ b/skeleton/bones/bone_phal_3_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_4_1_l.py
+++ b/skeleton/bones/bone_phal_4_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_4_1_r.py
+++ b/skeleton/bones/bone_phal_4_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_4_2_l.py
+++ b/skeleton/bones/bone_phal_4_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_4_2_r.py
+++ b/skeleton/bones/bone_phal_4_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_4_3_l.py
+++ b/skeleton/bones/bone_phal_4_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_4_3_r.py
+++ b/skeleton/bones/bone_phal_4_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_5_1_l.py
+++ b/skeleton/bones/bone_phal_5_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_5_1_r.py
+++ b/skeleton/bones/bone_phal_5_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_5_2_l.py
+++ b/skeleton/bones/bone_phal_5_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_5_2_r.py
+++ b/skeleton/bones/bone_phal_5_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_5_3_l.py
+++ b/skeleton/bones/bone_phal_5_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_phal_5_3_r.py
+++ b/skeleton/bones/bone_phal_5_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_pisiform_l.py
+++ b/skeleton/bones/bone_pisiform_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_pisiform_r.py
+++ b/skeleton/bones/bone_pisiform_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_radius_l.py
+++ b/skeleton/bones/bone_radius_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_radius_r.py
+++ b/skeleton/bones/bone_radius_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib10_l.py
+++ b/skeleton/bones/bone_rib10_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib10_r.py
+++ b/skeleton/bones/bone_rib10_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib11_l.py
+++ b/skeleton/bones/bone_rib11_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib11_r.py
+++ b/skeleton/bones/bone_rib11_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib12_l.py
+++ b/skeleton/bones/bone_rib12_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib12_r.py
+++ b/skeleton/bones/bone_rib12_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib1_l.py
+++ b/skeleton/bones/bone_rib1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib1_r.py
+++ b/skeleton/bones/bone_rib1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib2_l.py
+++ b/skeleton/bones/bone_rib2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib2_r.py
+++ b/skeleton/bones/bone_rib2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib3_l.py
+++ b/skeleton/bones/bone_rib3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib3_r.py
+++ b/skeleton/bones/bone_rib3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib4_l.py
+++ b/skeleton/bones/bone_rib4_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib4_r.py
+++ b/skeleton/bones/bone_rib4_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib5_l.py
+++ b/skeleton/bones/bone_rib5_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib5_r.py
+++ b/skeleton/bones/bone_rib5_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib6_l.py
+++ b/skeleton/bones/bone_rib6_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib6_r.py
+++ b/skeleton/bones/bone_rib6_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib7_l.py
+++ b/skeleton/bones/bone_rib7_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib7_r.py
+++ b/skeleton/bones/bone_rib7_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib8_l.py
+++ b/skeleton/bones/bone_rib8_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib8_r.py
+++ b/skeleton/bones/bone_rib8_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib9_l.py
+++ b/skeleton/bones/bone_rib9_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_rib9_r.py
+++ b/skeleton/bones/bone_rib9_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_sacrum.py
+++ b/skeleton/bones/bone_sacrum.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_scaphoid_l.py
+++ b/skeleton/bones/bone_scaphoid_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_scaphoid_r.py
+++ b/skeleton/bones/bone_scaphoid_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_scapula_l.py
+++ b/skeleton/bones/bone_scapula_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_scapula_r.py
+++ b/skeleton/bones/bone_scapula_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_sphenoid.py
+++ b/skeleton/bones/bone_sphenoid.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_stapes_l.py
+++ b/skeleton/bones/bone_stapes_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_stapes_r.py
+++ b/skeleton/bones/bone_stapes_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_sternum.py
+++ b/skeleton/bones/bone_sternum.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t1.py
+++ b/skeleton/bones/bone_t1.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t10.py
+++ b/skeleton/bones/bone_t10.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t11.py
+++ b/skeleton/bones/bone_t11.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t12.py
+++ b/skeleton/bones/bone_t12.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t2.py
+++ b/skeleton/bones/bone_t2.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t3.py
+++ b/skeleton/bones/bone_t3.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t4.py
+++ b/skeleton/bones/bone_t4.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t5.py
+++ b/skeleton/bones/bone_t5.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t6.py
+++ b/skeleton/bones/bone_t6.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t7.py
+++ b/skeleton/bones/bone_t7.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t8.py
+++ b/skeleton/bones/bone_t8.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t9.py
+++ b/skeleton/bones/bone_t9.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_1_1_l.py
+++ b/skeleton/bones/bone_t_phal_1_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_1_1_r.py
+++ b/skeleton/bones/bone_t_phal_1_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_1_2_l.py
+++ b/skeleton/bones/bone_t_phal_1_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_1_2_r.py
+++ b/skeleton/bones/bone_t_phal_1_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_2_1_l.py
+++ b/skeleton/bones/bone_t_phal_2_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_2_1_r.py
+++ b/skeleton/bones/bone_t_phal_2_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_2_2_l.py
+++ b/skeleton/bones/bone_t_phal_2_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_2_2_r.py
+++ b/skeleton/bones/bone_t_phal_2_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_2_3_l.py
+++ b/skeleton/bones/bone_t_phal_2_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_2_3_r.py
+++ b/skeleton/bones/bone_t_phal_2_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_3_1_l.py
+++ b/skeleton/bones/bone_t_phal_3_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_3_1_r.py
+++ b/skeleton/bones/bone_t_phal_3_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_3_2_l.py
+++ b/skeleton/bones/bone_t_phal_3_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_3_2_r.py
+++ b/skeleton/bones/bone_t_phal_3_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_3_3_l.py
+++ b/skeleton/bones/bone_t_phal_3_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_3_3_r.py
+++ b/skeleton/bones/bone_t_phal_3_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_4_1_l.py
+++ b/skeleton/bones/bone_t_phal_4_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_4_1_r.py
+++ b/skeleton/bones/bone_t_phal_4_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_4_2_l.py
+++ b/skeleton/bones/bone_t_phal_4_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_4_2_r.py
+++ b/skeleton/bones/bone_t_phal_4_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_4_3_l.py
+++ b/skeleton/bones/bone_t_phal_4_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_4_3_r.py
+++ b/skeleton/bones/bone_t_phal_4_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_5_1_l.py
+++ b/skeleton/bones/bone_t_phal_5_1_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_5_1_r.py
+++ b/skeleton/bones/bone_t_phal_5_1_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_5_2_l.py
+++ b/skeleton/bones/bone_t_phal_5_2_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_5_2_r.py
+++ b/skeleton/bones/bone_t_phal_5_2_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_5_3_l.py
+++ b/skeleton/bones/bone_t_phal_5_3_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_t_phal_5_3_r.py
+++ b/skeleton/bones/bone_t_phal_5_3_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_talus_l.py
+++ b/skeleton/bones/bone_talus_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_talus_r.py
+++ b/skeleton/bones/bone_talus_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_temp_l.py
+++ b/skeleton/bones/bone_temp_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_temp_r.py
+++ b/skeleton/bones/bone_temp_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_tibia_l.py
+++ b/skeleton/bones/bone_tibia_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_tibia_r.py
+++ b/skeleton/bones/bone_tibia_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_trapezium_l.py
+++ b/skeleton/bones/bone_trapezium_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_trapezium_r.py
+++ b/skeleton/bones/bone_trapezium_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_trapezoid_l.py
+++ b/skeleton/bones/bone_trapezoid_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_trapezoid_r.py
+++ b/skeleton/bones/bone_trapezoid_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_triquetrum_l.py
+++ b/skeleton/bones/bone_triquetrum_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_triquetrum_r.py
+++ b/skeleton/bones/bone_triquetrum_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_ulna_l.py
+++ b/skeleton/bones/bone_ulna_l.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/skeleton/bones/bone_ulna_r.py
+++ b/skeleton/bones/bone_ulna_r.py
@@ -25,3 +25,24 @@ def set_embodiment(state, material=None):
 def self_state():
     """Return the bone's current state."""
     return bone.self_state()
+
+def update_state(position=None, orientation=None, load=None, torsion=None):
+    """Atomically update bone state."""
+    bone.update_state(position=position, orientation=orientation,
+                      load=load, torsion=torsion)
+
+def current_state():
+    """Return the bone's current state."""
+    return bone.current_state()
+
+def is_healthy():
+    """Return True if the bone has no recorded faults."""
+    return bone.is_healthy()
+
+def clear_faults():
+    """Clear the bone's fault log."""
+    bone.clear_faults()
+
+def report_faults():
+    """Return list of recorded faults."""
+    return bone.report_faults()

--- a/tests/test_bone_state.py
+++ b/tests/test_bone_state.py
@@ -5,6 +5,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 from skeleton.base import BoneSpec
+from skeleton.bones import bone_c1
 
 class BoneStateTest(unittest.TestCase):
     def setUp(self):
@@ -35,6 +36,17 @@ class BoneStateTest(unittest.TestCase):
         state = self.bone.current_state()
         self.assertEqual(state['position'], (1,2,3))
         self.assertTrue(self.bone.is_healthy())
+
+    def test_module_wrappers(self):
+        bone_c1.clear_faults()
+        bone_c1.set_embodiment('virtual')
+        self.assertIsNone(bone_c1.bone.mass_kg())
+        self.assertFalse(bone_c1.is_healthy())
+        bone_c1.clear_faults()
+        bone_c1.update_state(position=(5,5,5), torsion=(1,0,0))
+        state = bone_c1.current_state()
+        self.assertEqual(state['position'], (5,5,5))
+        self.assertTrue(bone_c1.is_healthy())
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- add `update_state`, `current_state`, `is_healthy`, `clear_faults`, and `report_faults` wrappers to all bone modules
- extend tests to cover new wrappers

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858f2e4a1c4832497550ff65c94888e