### PR TITLE
Implement fault notifications across BoneSpec modules

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -171,20 +171,35 @@ class BoneSpec:
     def report_faults(self) -> List[str]:
         return list(self.state_faults)
 
-    def notify_fault(self) -> None:
+    def notify_fault(self, field: Optional["SkeletonField"] = None) -> None:
+        """Notify entangled bones of the most recent fault."""
         message = self.state_faults[-1] if self.state_faults else "fault"
         for link_id in self.entanglement_links:
-            pass  # In a full implementation this would propagate to neighbor bones
+            try:
+                if field:
+                    other = field.bones.get(link_id)
+                else:
+                    other = None
+                if other is not None:
+                    other.receive_fault_notice(self.domain_id, message)
+            except Exception as e:
+                self.state_faults.append(f"Notify fault error to {link_id}: {e}")
 
     def receive_fault_notice(self, from_domain: str, message: str) -> None:
-        self.state_faults.append(f"Neighbor {from_domain} fault: {message}")
+        try:
+            self.state_faults.append(f"Neighbor {from_domain} fault: {message}")
+        except Exception as e:
+            self.state_faults.append(f"Receive fault notice error from {from_domain}: {e}")
 
     def entangle(self, other_bone: "BoneSpec") -> None:
         """Create a bidirectional entanglement link with another bone."""
-        if other_bone.domain_id not in self.entanglement_links:
-            self.entanglement_links.append(other_bone.domain_id)
-        if self.domain_id not in other_bone.entanglement_links:
-            other_bone.entanglement_links.append(self.domain_id)
+        try:
+            if other_bone.domain_id not in self.entanglement_links:
+                self.entanglement_links.append(other_bone.domain_id)
+            if self.domain_id not in other_bone.entanglement_links:
+                other_bone.entanglement_links.append(self.domain_id)
+        except Exception as e:
+            self.state_faults.append(f"Entangle error: {e}")
 
     def receive_signal(self, signal: Dict[str, float], from_domain: str) -> float:
         """Accept a signal from another domain and regulate voltage."""
@@ -209,14 +224,20 @@ class BoneSpec:
 
     def transcend(self, intent: Optional[str] = None) -> None:
         """Increase internal energy and optionally log metaphysical intent."""
-        self.marrow.energy += 1.0
-        if intent:
-            self.resonance.append(intent)
+        try:
+            self.marrow.energy += 1.0
+            if intent:
+                self.resonance.append(intent)
+        except Exception as e:
+            self.state_faults.append(f"Transcend error: {e}")
 
     def invoke(self, field: "SkeletonField", intent: str) -> None:
         """Propagate a symbolic signal through the field."""
-        signal = {"voltage": self.voltage_potential, "type": intent}
-        field.propagate(self.domain_id, signal)
+        try:
+            signal = {"voltage": self.voltage_potential, "type": intent}
+            field.propagate(self.domain_id, signal)
+        except Exception as e:
+            self.state_faults.append(f"Invoke error: {e}")
 
     def audit(self) -> Dict[str, object]:
         """Return full state information including marrow audit."""

--- a/skeleton/bones/bone_c1.py
+++ b/skeleton/bones/bone_c1.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_c2.py
+++ b/skeleton/bones/bone_c2.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_c3.py
+++ b/skeleton/bones/bone_c3.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_c4.py
+++ b/skeleton/bones/bone_c4.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_c5.py
+++ b/skeleton/bones/bone_c5.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_c6.py
+++ b/skeleton/bones/bone_c6.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_c7.py
+++ b/skeleton/bones/bone_c7.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_calcaneus_l.py
+++ b/skeleton/bones/bone_calcaneus_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_calcaneus_r.py
+++ b/skeleton/bones/bone_calcaneus_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_capitate_l.py
+++ b/skeleton/bones/bone_capitate_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_capitate_r.py
+++ b/skeleton/bones/bone_capitate_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_clavicle_l.py
+++ b/skeleton/bones/bone_clavicle_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_clavicle_r.py
+++ b/skeleton/bones/bone_clavicle_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_coccyx.py
+++ b/skeleton/bones/bone_coccyx.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_cuboid_l.py
+++ b/skeleton/bones/bone_cuboid_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_cuboid_r.py
+++ b/skeleton/bones/bone_cuboid_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_ethmoid.py
+++ b/skeleton/bones/bone_ethmoid.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_femur_l.py
+++ b/skeleton/bones/bone_femur_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_femur_r.py
+++ b/skeleton/bones/bone_femur_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_fibula_l.py
+++ b/skeleton/bones/bone_fibula_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_fibula_r.py
+++ b/skeleton/bones/bone_fibula_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_frontal.py
+++ b/skeleton/bones/bone_frontal.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_hamate_l.py
+++ b/skeleton/bones/bone_hamate_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_hamate_r.py
+++ b/skeleton/bones/bone_hamate_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_hip_l.py
+++ b/skeleton/bones/bone_hip_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_hip_r.py
+++ b/skeleton/bones/bone_hip_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_humerus_l.py
+++ b/skeleton/bones/bone_humerus_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_humerus_r.py
+++ b/skeleton/bones/bone_humerus_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_hyoid.py
+++ b/skeleton/bones/bone_hyoid.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_incus_l.py
+++ b/skeleton/bones/bone_incus_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_incus_r.py
+++ b/skeleton/bones/bone_incus_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_intermediate_cuneiform_l.py
+++ b/skeleton/bones/bone_intermediate_cuneiform_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_intermediate_cuneiform_r.py
+++ b/skeleton/bones/bone_intermediate_cuneiform_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_l1.py
+++ b/skeleton/bones/bone_l1.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_l2.py
+++ b/skeleton/bones/bone_l2.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_l3.py
+++ b/skeleton/bones/bone_l3.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_l4.py
+++ b/skeleton/bones/bone_l4.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_l5.py
+++ b/skeleton/bones/bone_l5.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_lateral_cuneiform_l.py
+++ b/skeleton/bones/bone_lateral_cuneiform_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_lateral_cuneiform_r.py
+++ b/skeleton/bones/bone_lateral_cuneiform_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_lunate_l.py
+++ b/skeleton/bones/bone_lunate_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_lunate_r.py
+++ b/skeleton/bones/bone_lunate_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_malleus_l.py
+++ b/skeleton/bones/bone_malleus_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_malleus_r.py
+++ b/skeleton/bones/bone_malleus_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mandible.py
+++ b/skeleton/bones/bone_mandible.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_medial_cuneiform_l.py
+++ b/skeleton/bones/bone_medial_cuneiform_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_medial_cuneiform_r.py
+++ b/skeleton/bones/bone_medial_cuneiform_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta1_l.py
+++ b/skeleton/bones/bone_meta1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta1_r.py
+++ b/skeleton/bones/bone_meta1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta2_l.py
+++ b/skeleton/bones/bone_meta2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta2_r.py
+++ b/skeleton/bones/bone_meta2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta3_l.py
+++ b/skeleton/bones/bone_meta3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta3_r.py
+++ b/skeleton/bones/bone_meta3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta4_l.py
+++ b/skeleton/bones/bone_meta4_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta4_r.py
+++ b/skeleton/bones/bone_meta4_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta5_l.py
+++ b/skeleton/bones/bone_meta5_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_meta5_r.py
+++ b/skeleton/bones/bone_meta5_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt1_l.py
+++ b/skeleton/bones/bone_mt1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt1_r.py
+++ b/skeleton/bones/bone_mt1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt2_l.py
+++ b/skeleton/bones/bone_mt2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt2_r.py
+++ b/skeleton/bones/bone_mt2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt3_l.py
+++ b/skeleton/bones/bone_mt3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt3_r.py
+++ b/skeleton/bones/bone_mt3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt4_l.py
+++ b/skeleton/bones/bone_mt4_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt4_r.py
+++ b/skeleton/bones/bone_mt4_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt5_l.py
+++ b/skeleton/bones/bone_mt5_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_mt5_r.py
+++ b/skeleton/bones/bone_mt5_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_navicular_l.py
+++ b/skeleton/bones/bone_navicular_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_navicular_r.py
+++ b/skeleton/bones/bone_navicular_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_occipital.py
+++ b/skeleton/bones/bone_occipital.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_par_l.py
+++ b/skeleton/bones/bone_par_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_par_r.py
+++ b/skeleton/bones/bone_par_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_patella_l.py
+++ b/skeleton/bones/bone_patella_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_patella_r.py
+++ b/skeleton/bones/bone_patella_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_1_1_l.py
+++ b/skeleton/bones/bone_phal_1_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_1_1_r.py
+++ b/skeleton/bones/bone_phal_1_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_1_2_l.py
+++ b/skeleton/bones/bone_phal_1_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_1_2_r.py
+++ b/skeleton/bones/bone_phal_1_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_2_1_l.py
+++ b/skeleton/bones/bone_phal_2_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_2_1_r.py
+++ b/skeleton/bones/bone_phal_2_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_2_2_l.py
+++ b/skeleton/bones/bone_phal_2_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_2_2_r.py
+++ b/skeleton/bones/bone_phal_2_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_2_3_l.py
+++ b/skeleton/bones/bone_phal_2_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_2_3_r.py
+++ b/skeleton/bones/bone_phal_2_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_3_1_l.py
+++ b/skeleton/bones/bone_phal_3_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_3_1_r.py
+++ b/skeleton/bones/bone_phal_3_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_3_2_l.py
+++ b/skeleton/bones/bone_phal_3_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_3_2_r.py
+++ b/skeleton/bones/bone_phal_3_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_3_3_l.py
+++ b/skeleton/bones/bone_phal_3_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_3_3_r.py
+++ b/skeleton/bones/bone_phal_3_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_4_1_l.py
+++ b/skeleton/bones/bone_phal_4_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_4_1_r.py
+++ b/skeleton/bones/bone_phal_4_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_4_2_l.py
+++ b/skeleton/bones/bone_phal_4_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_4_2_r.py
+++ b/skeleton/bones/bone_phal_4_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_4_3_l.py
+++ b/skeleton/bones/bone_phal_4_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_4_3_r.py
+++ b/skeleton/bones/bone_phal_4_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_5_1_l.py
+++ b/skeleton/bones/bone_phal_5_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_5_1_r.py
+++ b/skeleton/bones/bone_phal_5_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_5_2_l.py
+++ b/skeleton/bones/bone_phal_5_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_5_2_r.py
+++ b/skeleton/bones/bone_phal_5_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_5_3_l.py
+++ b/skeleton/bones/bone_phal_5_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_phal_5_3_r.py
+++ b/skeleton/bones/bone_phal_5_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_pisiform_l.py
+++ b/skeleton/bones/bone_pisiform_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_pisiform_r.py
+++ b/skeleton/bones/bone_pisiform_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_radius_l.py
+++ b/skeleton/bones/bone_radius_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_radius_r.py
+++ b/skeleton/bones/bone_radius_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib10_l.py
+++ b/skeleton/bones/bone_rib10_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib10_r.py
+++ b/skeleton/bones/bone_rib10_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib11_l.py
+++ b/skeleton/bones/bone_rib11_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib11_r.py
+++ b/skeleton/bones/bone_rib11_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib12_l.py
+++ b/skeleton/bones/bone_rib12_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib12_r.py
+++ b/skeleton/bones/bone_rib12_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib1_l.py
+++ b/skeleton/bones/bone_rib1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib1_r.py
+++ b/skeleton/bones/bone_rib1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib2_l.py
+++ b/skeleton/bones/bone_rib2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib2_r.py
+++ b/skeleton/bones/bone_rib2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib3_l.py
+++ b/skeleton/bones/bone_rib3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib3_r.py
+++ b/skeleton/bones/bone_rib3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib4_l.py
+++ b/skeleton/bones/bone_rib4_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib4_r.py
+++ b/skeleton/bones/bone_rib4_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib5_l.py
+++ b/skeleton/bones/bone_rib5_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib5_r.py
+++ b/skeleton/bones/bone_rib5_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib6_l.py
+++ b/skeleton/bones/bone_rib6_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib6_r.py
+++ b/skeleton/bones/bone_rib6_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib7_l.py
+++ b/skeleton/bones/bone_rib7_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib7_r.py
+++ b/skeleton/bones/bone_rib7_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib8_l.py
+++ b/skeleton/bones/bone_rib8_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib8_r.py
+++ b/skeleton/bones/bone_rib8_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib9_l.py
+++ b/skeleton/bones/bone_rib9_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_rib9_r.py
+++ b/skeleton/bones/bone_rib9_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_sacrum.py
+++ b/skeleton/bones/bone_sacrum.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_scaphoid_l.py
+++ b/skeleton/bones/bone_scaphoid_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_scaphoid_r.py
+++ b/skeleton/bones/bone_scaphoid_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_scapula_l.py
+++ b/skeleton/bones/bone_scapula_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_scapula_r.py
+++ b/skeleton/bones/bone_scapula_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_sphenoid.py
+++ b/skeleton/bones/bone_sphenoid.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_stapes_l.py
+++ b/skeleton/bones/bone_stapes_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_stapes_r.py
+++ b/skeleton/bones/bone_stapes_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_sternum.py
+++ b/skeleton/bones/bone_sternum.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t1.py
+++ b/skeleton/bones/bone_t1.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t10.py
+++ b/skeleton/bones/bone_t10.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t11.py
+++ b/skeleton/bones/bone_t11.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t12.py
+++ b/skeleton/bones/bone_t12.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t2.py
+++ b/skeleton/bones/bone_t2.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t3.py
+++ b/skeleton/bones/bone_t3.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t4.py
+++ b/skeleton/bones/bone_t4.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t5.py
+++ b/skeleton/bones/bone_t5.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t6.py
+++ b/skeleton/bones/bone_t6.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t7.py
+++ b/skeleton/bones/bone_t7.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t8.py
+++ b/skeleton/bones/bone_t8.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t9.py
+++ b/skeleton/bones/bone_t9.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_1_1_l.py
+++ b/skeleton/bones/bone_t_phal_1_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_1_1_r.py
+++ b/skeleton/bones/bone_t_phal_1_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_1_2_l.py
+++ b/skeleton/bones/bone_t_phal_1_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_1_2_r.py
+++ b/skeleton/bones/bone_t_phal_1_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_2_1_l.py
+++ b/skeleton/bones/bone_t_phal_2_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_2_1_r.py
+++ b/skeleton/bones/bone_t_phal_2_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_2_2_l.py
+++ b/skeleton/bones/bone_t_phal_2_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_2_2_r.py
+++ b/skeleton/bones/bone_t_phal_2_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_2_3_l.py
+++ b/skeleton/bones/bone_t_phal_2_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_2_3_r.py
+++ b/skeleton/bones/bone_t_phal_2_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_3_1_l.py
+++ b/skeleton/bones/bone_t_phal_3_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_3_1_r.py
+++ b/skeleton/bones/bone_t_phal_3_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_3_2_l.py
+++ b/skeleton/bones/bone_t_phal_3_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_3_2_r.py
+++ b/skeleton/bones/bone_t_phal_3_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_3_3_l.py
+++ b/skeleton/bones/bone_t_phal_3_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_3_3_r.py
+++ b/skeleton/bones/bone_t_phal_3_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_4_1_l.py
+++ b/skeleton/bones/bone_t_phal_4_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_4_1_r.py
+++ b/skeleton/bones/bone_t_phal_4_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_4_2_l.py
+++ b/skeleton/bones/bone_t_phal_4_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_4_2_r.py
+++ b/skeleton/bones/bone_t_phal_4_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_4_3_l.py
+++ b/skeleton/bones/bone_t_phal_4_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_4_3_r.py
+++ b/skeleton/bones/bone_t_phal_4_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_5_1_l.py
+++ b/skeleton/bones/bone_t_phal_5_1_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_5_1_r.py
+++ b/skeleton/bones/bone_t_phal_5_1_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_5_2_l.py
+++ b/skeleton/bones/bone_t_phal_5_2_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_5_2_r.py
+++ b/skeleton/bones/bone_t_phal_5_2_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_5_3_l.py
+++ b/skeleton/bones/bone_t_phal_5_3_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_t_phal_5_3_r.py
+++ b/skeleton/bones/bone_t_phal_5_3_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_talus_l.py
+++ b/skeleton/bones/bone_talus_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_talus_r.py
+++ b/skeleton/bones/bone_talus_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_temp_l.py
+++ b/skeleton/bones/bone_temp_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_temp_r.py
+++ b/skeleton/bones/bone_temp_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_tibia_l.py
+++ b/skeleton/bones/bone_tibia_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_tibia_r.py
+++ b/skeleton/bones/bone_tibia_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_trapezium_l.py
+++ b/skeleton/bones/bone_trapezium_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_trapezium_r.py
+++ b/skeleton/bones/bone_trapezium_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_trapezoid_l.py
+++ b/skeleton/bones/bone_trapezoid_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_trapezoid_r.py
+++ b/skeleton/bones/bone_trapezoid_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_triquetrum_l.py
+++ b/skeleton/bones/bone_triquetrum_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_triquetrum_r.py
+++ b/skeleton/bones/bone_triquetrum_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_ulna_l.py
+++ b/skeleton/bones/bone_ulna_l.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/skeleton/bones/bone_ulna_r.py
+++ b/skeleton/bones/bone_ulna_r.py
@@ -46,3 +46,8 @@ def clear_faults():
 def report_faults():
     """Return list of recorded faults."""
     return bone.report_faults()
+
+
+def notify_fault(field=None):
+    """Notify linked bones of a fault."""
+    bone.notify_fault(field)

--- a/tests/test_fault_notify.py
+++ b/tests/test_fault_notify.py
@@ -1,0 +1,26 @@
+import os
+import sys
+import unittest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from skeleton.base import BoneSpec
+from skeleton.field import SkeletonField
+
+class FaultNotifyTest(unittest.TestCase):
+    def test_notify_fault_propagation(self):
+        b1 = BoneSpec(name='A', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='',
+                      variations='', unique_id='A')
+        b2 = BoneSpec(name='B', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='',
+                      variations='', unique_id='B')
+        b1.entangle(b2)
+        field = SkeletonField([b1, b2])
+        b1.state_faults.append('test fault')
+        b1.notify_fault(field)
+        self.assertIn('Neighbor A fault: test fault', b2.state_faults)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- support notifying entangled bones of faults via `notify_fault`
- add robust error handling to several BoneSpec methods
- expose `notify_fault` wrapper in every bone module
- test propagation of fault notifications

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68590c44a8a883248142093acea608da