### PR TITLE
Improve BoneSpec dataset integration

### DIFF
--- a/assemble_skeleton.py
+++ b/assemble_skeleton.py
@@ -4,7 +4,7 @@ import json
 
 
 if __name__ == "__main__":
-    bones = load_bones()
+    bones = load_bones("female_21_baseline")
     field = SkeletonField(bones)
     data = {
         "bones": {b.unique_id: b.self_state() for b in bones},

--- a/skeleton/bones/__init__.py
+++ b/skeleton/bones/__init__.py
@@ -5,14 +5,19 @@ from typing import List
 
 from ..base import BoneSpec
 from ..field import SkeletonField
+from ..datasets import load_dataset
 
-def load_bones() -> List[BoneSpec]:
+def load_bones(dataset_name: str = "female_21_baseline") -> List[BoneSpec]:
     bones: List[BoneSpec] = []
     for file in Path(__file__).parent.glob('*.py'):
         if file.name == '__init__.py':
             continue
         module = import_module(f'skeleton.bones.{file.stem}')
         bones.append(module.bone)
+
+    dataset = load_dataset(dataset_name)
+    for b in bones:
+        b.apply_dataset(dataset)
 
     # establish entanglements based on articulations
     name_map = {b.name: b for b in bones}
@@ -25,8 +30,8 @@ def load_bones() -> List[BoneSpec]:
     return bones
 
 
-def load_field() -> SkeletonField:
+def load_field(dataset_name: str = "female_21_baseline") -> SkeletonField:
     """Return a SkeletonField with all discovered bones registered."""
-    bones = load_bones()
+    bones = load_bones(dataset_name)
     field = SkeletonField(bones)
     return field

--- a/skeleton/field.py
+++ b/skeleton/field.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 from .base import BoneSpec
 
@@ -85,4 +85,13 @@ class SkeletonField:
     def faults(self) -> Dict[str, List[str]]:
         """Return fault lists per bone."""
         return {d: b.report_faults() for d, b in self.bones.items() if not b.is_healthy()}
+
+    def audit_metrics(self) -> Dict[str, Dict[str, Tuple[Optional[float], Optional[float]]]]:
+        """Return dataset metric discrepancies for all bones."""
+        report: Dict[str, Dict[str, Tuple[Optional[float], Optional[float]]]] = {}
+        for bone in self.bones.values():
+            diff = bone.validate_metrics()
+            if diff:
+                report[bone.unique_id] = diff
+        return report
 

--- a/tests/test_dataset_summary.py
+++ b/tests/test_dataset_summary.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import json
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from skeleton.bones import load_bones
+from skeleton.field import SkeletonField
+
+if __name__ == "__main__":
+    bones = load_bones("female_21_baseline")
+    field = SkeletonField(bones)
+    summary = {b.unique_id: b.export() for b in bones}
+    report = {
+        "health": field.health(),
+        "faults": field.faults(),
+        "metrics_audit": field.audit_metrics(),
+        "bones": summary,
+    }
+    print(json.dumps(report, indent=2))


### PR DESCRIPTION
## Summary
- integrate dataset metrics when loading bone modules
- support synthetic materials and dataset audit for each bone
- add skeleton-wide metric audit
- include dataset summary script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859319f7bc4832495d516f4e2968ead