### PR TITLE
Fix propagate for domain-based links

### DIFF
--- a/skeleton/field.py
+++ b/skeleton/field.py
@@ -46,6 +46,7 @@ class SkeletonField:
 
 
     def propagate(self, from_domain: str, signal: Dict[str, float]) -> None:
+        """Propagate a signal through the entanglement network."""
         origin = self.bones.get(from_domain)
         if not origin:
             return
@@ -55,9 +56,11 @@ class SkeletonField:
             if b.domain_id in visited:
                 return
             visited.add(b.domain_id)
-            for other in b.entanglement_links:
-                other.receive_signal_packet(signal, b.domain_id)
-                _prop(other)
+            for link_id in b.entanglement_links:
+                other = self.bones.get(link_id)
+                if other is not None:
+                    other.receive_signal_packet(signal, b.domain_id)
+                    _prop(other)
 
         _prop(origin)
 


### PR DESCRIPTION
## Summary
- correct entanglement link type to `List[str]`
- allow `emit_signal` to resolve domain IDs via field
- fix `SkeletonField.propagate` to map domain IDs to bone objects

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4eb42bfc8324827dbd646c1c1f3b