### PR TITLE
Fix signal propagation via entanglement

### DIFF
--- a/skeleton/field.py
+++ b/skeleton/field.py
@@ -55,7 +55,10 @@ class SkeletonField:
             if b.domain_id in visited:
                 return
             visited.add(b.domain_id)
-            for other in b.entanglement_links:
+            for other_id in b.entanglement_links:
+                other = self.bones.get(other_id)
+                if other is None:
+                    continue
                 other.receive_signal_packet(signal, b.domain_id)
                 _prop(other)
 

--- a/tests/test_meta_field.py
+++ b/tests/test_meta_field.py
@@ -22,5 +22,20 @@ class FieldMetaTest(unittest.TestCase):
         self.assertIn('awaken', b1.resonance)
         self.assertIn('awaken', b2.resonance)
 
+    def test_signal_propagation(self):
+        b1 = BoneSpec(name='A', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='',
+                      variations='', unique_id='A2')
+        b2 = BoneSpec(name='B', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='',
+                      variations='', unique_id='B2')
+        b1.entangle(b2)
+        field = SkeletonField([b1, b2])
+        b1.voltage_potential = 1.0
+        b1.invoke(field, 'EMG')
+        self.assertGreater(b2.voltage_potential, 0.0)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- fix `SkeletonField.propagate` to resolve bone ids to objects
- add regression test covering propagation through `invoke`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4eb42bfc8324827dbd646c1c1f3b