### PR TITLE
Fix propagate using bone ids

### DIFF
--- a/skeleton/field.py
+++ b/skeleton/field.py
@@ -55,7 +55,10 @@ class SkeletonField:
             if b.domain_id in visited:
                 return
             visited.add(b.domain_id)
-            for other in b.entanglement_links:
+            for link_id in b.entanglement_links:
+                other = self.bones.get(link_id)
+                if other is None:
+                    continue
                 other.receive_signal_packet(signal, b.domain_id)
                 _prop(other)
 

--- a/tests/test_signal_propagation.py
+++ b/tests/test_signal_propagation.py
@@ -1,0 +1,27 @@
+import os
+import sys
+import unittest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from skeleton.base import BoneSpec
+from skeleton.field import SkeletonField
+
+class SignalPropagationTest(unittest.TestCase):
+    def test_propagate_signal(self):
+        b1 = BoneSpec(name='A', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='',
+                      variations='', unique_id='A1')
+        b2 = BoneSpec(name='B', bone_type='long', location={}, articulations=[],
+                      dimensions={'length_cm':1,'width_cm':1,'thickness_cm':1},
+                      function=[], notable_features=[], developmental_notes='',
+                      variations='', unique_id='B1')
+        b1.entangle(b2)
+        field = SkeletonField([b1, b2])
+        signal = {'voltage': 4.0, 'type': 'EMG'}
+        field.propagate(b1.domain_id, signal)
+        self.assertGreater(b2.voltage_potential, 0)
+        self.assertAlmostEqual(field.total_voltage(), b1.voltage_potential + b2.voltage_potential)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- fix SkeletonField.propagate handling of entanglement links
- add regression test for propagate signal

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4eb42bfc8324827dbd646c1c1f3b