### PR TITLE
Fix dataset linkage when bone metrics missing

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -321,12 +321,12 @@ class BoneSpec:
         """Populate metric fields from the dataset."""
         key = self.name
         metrics = dataset.get(key) or dataset.get(self.unique_id)
+        self.dataset = dataset
         if metrics is None:
             warnings.warn(f"Metrics for {self.name} not found in dataset")
             self.dataset_key = None
             return
         self.dataset_key = key
-        self.dataset = dataset
         for field_name in ["length_cm", "width_cm", "thickness_cm", "height_cm", "mass_g", "density_kg_m3"]:
             if field_name in metrics:
                 target_dict = self.dimensions if field_name.endswith("_cm") else self.material

--- a/tests/test_dataset_link.py
+++ b/tests/test_dataset_link.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import unittest
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from skeleton.bones import load_bones
+
+class DatasetLinkTest(unittest.TestCase):
+    def test_dataset_available_even_if_metrics_missing(self):
+        bones = load_bones('female_21_baseline')
+        # pick a bone not present in dataset
+        bone = next(b for b in bones if b.name == 'C1')
+        self.assertIsNotNone(bone.dataset)
+        # dataset_key should be None but we should still be able to set material
+        bone.set_material('Ti6Al4V')
+        self.assertIn('density', bone.material)
+        self.assertNotIn('No dataset available for material lookup', bone.state_faults)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- ensure `BoneSpec.apply_dataset` keeps dataset link even if metrics are missing
- add regression test verifying material lookup works for bones without dataset metrics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b746cbe0c8324ae1667c507d28a7c