### PR TITLE
Fix dataset lookup for spaced bone names

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -322,6 +322,12 @@ class BoneSpec:
         key = self.name
         metrics = dataset.get(key) or dataset.get(self.unique_id)
         if metrics is None:
+            alt_key = key.replace(" ", "")
+            if alt_key != key:
+                metrics = dataset.get(alt_key)
+                if metrics is not None:
+                    key = alt_key
+        if metrics is None:
             warnings.warn(f"Metrics for {self.name} not found in dataset")
             self.dataset_key = None
             return

--- a/tests/test_dataset_integration.py
+++ b/tests/test_dataset_integration.py
@@ -1,0 +1,20 @@
+import os
+import sys
+import unittest
+import warnings
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from skeleton.bones import load_bones
+
+class DatasetIntegrationTest(unittest.TestCase):
+    def test_hipbone_dataset_applied(self):
+        warnings.filterwarnings("ignore")
+        bones = load_bones("female_21_baseline")
+        hip = next(b for b in bones if b.unique_id == "BONE_HIP_L")
+        self.assertEqual(hip.dataset_key, "HipBone")
+        self.assertAlmostEqual(hip.dimensions.get("length_cm"), 23.0)
+        self.assertEqual(hip.material.get("mass_g"), 120)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- allow `apply_dataset` to lookup keys without spaces
- add regression test verifying Hip Bone metrics load correctly

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b746cbe0c8324ae1667c507d28a7c