### PR TITLE
Fix dataset key tracking in BoneSpec.apply_dataset

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -320,7 +320,10 @@ class BoneSpec:
     def apply_dataset(self, dataset: Dict[str, dict]) -> None:
         """Populate metric fields from the dataset."""
         key = self.name
-        metrics = dataset.get(key) or dataset.get(self.unique_id)
+        metrics = dataset.get(key)
+        if metrics is None:
+            key = self.unique_id
+            metrics = dataset.get(key)
         if metrics is None:
             warnings.warn(f"Metrics for {self.name} not found in dataset")
             self.dataset_key = None


### PR DESCRIPTION
## Summary
- preserve which key was used to lookup metrics when applying dataset data

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b746cbe0c8324ae1667c507d28a7c