### PR TITLE
Improve test reliability and add CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,22 @@
+name: Python package
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest
+    - name: Run tests
+      run: pytest -q

--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -318,7 +318,12 @@ class BoneSpec:
 
     # Dataset integration helpers
     def apply_dataset(self, dataset: Dict[str, dict]) -> None:
-        """Populate metric fields from the dataset."""
+        """Populate metric fields from the dataset.
+
+        This also stores the dataset reference so the bone can use
+        dataset-based utilities later (e.g., `set_material`).
+        """
+        self.dataset = dataset
         key = self.name
         metrics = dataset.get(key)
         if metrics is None:

--- a/skeleton/bones/bone_hip_l.py
+++ b/skeleton/bones/bone_hip_l.py
@@ -2,7 +2,7 @@
 from ..base import BoneSpec
 
 bone = BoneSpec(
-    name = 'Hip Bone',
+    name = 'HipBone',
     bone_type = 'irregular',
     location = {'region': 'pelvis', 'proximal_connection': 'sacrum', 'distal_connection': 'femur'},
     articulations = [],

--- a/skeleton/bones/bone_hip_r.py
+++ b/skeleton/bones/bone_hip_r.py
@@ -2,7 +2,7 @@
 from ..base import BoneSpec
 
 bone = BoneSpec(
-    name = 'Hip Bone',
+    name = 'HipBone',
     bone_type = 'irregular',
     location = {'region': 'pelvis', 'proximal_connection': 'sacrum', 'distal_connection': 'femur'},
     articulations = [],


### PR DESCRIPTION
## Summary
- keep dataset reference when applying dataset so bones can access material info
- rename hip bone modules to match dataset keys
- run tests in GitHub Actions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7e1585f88324a68a303cf3e7e06d