### PR TITLE
Fix dataset integration for tests

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -322,6 +322,9 @@ class BoneSpec:
         key = self.name
         metrics = dataset.get(key)
         if metrics is None:
+            key = self.name.replace(" ", "")
+            metrics = dataset.get(key)
+        if metrics is None:
             key = self.unique_id
             metrics = dataset.get(key)
 

--- a/skeleton/bones/__init__.py
+++ b/skeleton/bones/__init__.py
@@ -17,6 +17,7 @@ def load_bones(dataset_name: str = "female_21_baseline") -> List[BoneSpec]:
 
     dataset = load_dataset(dataset_name)
     for b in bones:
+        b.dataset = dataset
         b.apply_dataset(dataset)
 
     # establish entanglements based on articulations


### PR DESCRIPTION
## Summary
- persist dataset reference when loading bones
- allow `apply_dataset` to match dataset keys without spaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7e1585f88324a68a303cf3e7e06d