### PR TITLE
Improve dataset loading and add CI

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.11', '3.12']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+      - name: Run tests
+        run: |
+          python -m unittest discover -s tests -v

--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -318,9 +318,14 @@ class BoneSpec:
 
     # Dataset integration helpers
     def apply_dataset(self, dataset: Dict[str, dict]) -> None:
-        """Populate metric fields from the dataset."""
+        """Populate metric fields from the dataset and remember the source."""
+        self.dataset = dataset
         key = self.name
         metrics = dataset.get(key)
+        if metrics is None:
+            metrics = dataset.get(self.name.replace(" ", ""))
+            if metrics is not None:
+                key = self.name.replace(" ", "")
         if metrics is None:
             key = self.unique_id
             metrics = dataset.get(key)

--- a/skeleton/bones/__init__.py
+++ b/skeleton/bones/__init__.py
@@ -17,6 +17,7 @@ def load_bones(dataset_name: str = "female_21_baseline") -> List[BoneSpec]:
 
     dataset = load_dataset(dataset_name)
     for b in bones:
+        b.dataset = dataset
         b.apply_dataset(dataset)
 
     # establish entanglements based on articulations


### PR DESCRIPTION
## Summary
- store dataset in each `BoneSpec`
- match dataset keys that omit spaces
- persist dataset reference when loading bones
- add GitHub Actions workflow to run unit tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7e1585f88324a68a303cf3e7e06d