### PR TITLE
Fix dataset handling for bones and ensure dataset integration tests pass

### DIFF
--- a/skeleton/base.py
+++ b/skeleton/base.py
@@ -318,9 +318,19 @@ class BoneSpec:
 
     # Dataset integration helpers
     def apply_dataset(self, dataset: Dict[str, dict]) -> None:
-        """Populate metric fields from the dataset."""
+        """Populate metric fields from the dataset and retain reference."""
+        # store dataset for later material lookups
+        self.dataset = dataset
+
         key = self.name
         metrics = dataset.get(key)
+        if metrics is None:
+            # attempt common canonicalizations (e.g. HipBone vs "Hip Bone")
+            alt_key = key.replace(" ", "").replace("-", "")
+            metrics = dataset.get(alt_key)
+            if metrics is not None:
+                key = alt_key
+
         if metrics is None:
             key = self.unique_id
             metrics = dataset.get(key)
@@ -329,6 +339,7 @@ class BoneSpec:
             warnings.warn(f"Metrics for {self.name} not found in dataset")
             self.dataset_key = None
             return
+
         self.dataset_key = key
         for field_name in ["length_cm", "width_cm", "thickness_cm", "height_cm", "mass_g", "density_kg_m3"]:
             if field_name in metrics:

--- a/skeleton/bones/__init__.py
+++ b/skeleton/bones/__init__.py
@@ -17,6 +17,8 @@ def load_bones(dataset_name: str = "female_21_baseline") -> List[BoneSpec]:
 
     dataset = load_dataset(dataset_name)
     for b in bones:
+        # keep dataset reference for later material lookups
+        b.dataset = dataset
         b.apply_dataset(dataset)
 
     # establish entanglements based on articulations


### PR DESCRIPTION
## Summary
- store dataset reference when loading bones
- improve dataset application logic with canonicalized keys and dataset persistence
- all tests pass

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685b7e1585f88324a68a303cf3e7e06d