### PR TITLE
Add neural sensors and healing engine

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -24,6 +24,17 @@ jobs:
       run: python -m eval_skeleton --material organic --export-dir reports/organic
     - name: Validate skeleton (Ti6Al4V)
       run: python -m eval_skeleton --material Ti6Al4V --export-dir reports/ti
+    - name: Run demos
+      run: |
+        python bin/demo_healing.py --output healing.png
+        python bin/demo_reflexes.py --output reflex.txt
+    - name: Upload demo artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: demos
+        path: |
+          healing.png
+          reflex.txt
     - name: Upload reports
       uses: actions/upload-artifact@v4
       with:

--- a/autonomic/__init__.py
+++ b/autonomic/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['AutonomicAgent']

--- a/autonomic/autonomic_agent.py
+++ b/autonomic/autonomic_agent.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AutonomicAgent:
+    """Very small autonomic regulation placeholder."""
+
+    energy_agent: "EnergyAgent"
+    core_temp_c: float = 37.0
+    sweat: bool = False
+    shiver: bool = False
+
+    def update(self, dt: float) -> None:
+        if self.core_temp_c > 37.4:
+            self.sweat = True
+            self.energy_agent.kcal += 0.1 * dt
+        else:
+            self.sweat = False
+        if self.core_temp_c < 36.3:
+            self.shiver = True
+            self.energy_agent.kcal += 0.2 * dt
+        else:
+            self.shiver = False
+        deviation = self.core_temp_c - 37.0
+        self.energy_agent.kcal += abs(deviation) * 0.05 * dt

--- a/bin/demo_healing.py
+++ b/bin/demo_healing.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import matplotlib.pyplot as plt
+
+from skeleton.bones import load_bones
+from healing.healing_engine import HealingEngine
+
+
+def run(output="healing.png"):
+    bones = load_bones("female_21_baseline")
+    tib = next(b for b in bones if b.unique_id == "BONE_TIBIA_L")
+    tib.material["E_base"] = 1.0
+    engine = HealingEngine({tib.unique_id: tib})
+    engine.start_healing(tib.unique_id)
+    times = []
+    strengths = []
+    for _ in range(30):
+        engine.update(7*24*3600/30)
+        times.append(engine.time)
+        strengths.append(tib.material.get("E",0.0))
+    plt.plot(times, strengths)
+    plt.xlabel("time (s)")
+    plt.ylabel("E")
+    plt.savefig(output)
+    print(f"plot saved to {output}")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", default="healing.png")
+    args = ap.parse_args()
+    run(args.output)

--- a/bin/demo_reflexes.py
+++ b/bin/demo_reflexes.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+from __future__ import annotations
+
+import argparse
+import time
+
+from skeleton.bones import load_bones
+from geometry.geometry_agent import GeometryAgent
+from joints.joint_spec import hinge
+from kinematics.kinematic_chain import KinematicChain
+from physics.physics_agent import PhysicsAgent
+from soft.muscle_spec import MuscleSpec
+from soft.muscle_agent import MuscleAgent
+from control.control_agent import ControlAgent
+from sensors.receptor_spec import ReceptorSpec
+from sensors.sensor_agent import SensorAgent
+from neuro.neuro_agent import NeuroAgent
+from energy.energy_agent import EnergyAgent
+
+
+def build():
+    bones = load_bones("female_21_baseline")
+    hum = next(b for b in bones if b.unique_id == "BONE_HUMERUS_L")
+    ulna = next(b for b in bones if b.unique_id == "BONE_ULNA_L")
+    for b in (hum, ulna):
+        b.set_material("organic")
+        b.set_embodiment("physical", b.material)
+        GeometryAgent(b).compute()
+    j = hinge("elbow", hum.unique_id, ulna.unique_id, axis=(1,0,0), limit=(-180,0), origin_xyz=(0,0,hum.dimensions.get("length_cm",30)/100))
+    chain = KinematicChain({hum.unique_id: hum, ulna.unique_id: ulna}, [j], hum.unique_id)
+    muscle = MuscleAgent(MuscleSpec("biceps", {"bone_uid": hum.unique_id}, {"bone_uid": ulna.unique_id},300.0,10.0,10.0),"elbow",0.03)
+    ctrl = ControlAgent([muscle.spec.name])
+    sensor = SensorAgent(ReceptorSpec("sp","muscle_spindle",0.0,{"bone_uid":""}), muscle=muscle, physics=None, joint_name="elbow")
+    agent = PhysicsAgent(chain, muscles=[muscle], controller=ctrl, energy=EnergyAgent(), neuro=NeuroAgent([sensor]))
+    sensor.physics = agent
+    return agent, ctrl
+
+
+def run(duration=1.0, output=None):
+    agent, ctrl = build()
+    t = 0.0
+    while t < duration:
+        ctrl.update(1/240, {"biceps": [0.0]})
+        agent.step(1/240)
+        t += 1/240
+    angle = agent.get_joint_state("elbow")
+    print(f"final angle: {angle:.2f} deg")
+    if output:
+        with open(output, "w") as fh:
+            fh.write("demo complete")
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--output", default=None)
+    args = ap.parse_args()
+    run(output=args.output)

--- a/damage/__init__.py
+++ b/damage/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['DamageEngine', 'DamageEvent']

--- a/damage/damage_engine.py
+++ b/damage/damage_engine.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+
+@dataclass
+class DamageEvent:
+    uid: str
+    severity: float
+    time: float
+
+
+@dataclass
+class DamageEngine:
+    """Detect simple bone damage from stress."""
+
+    bones: Dict[str, "BoneSpec"]
+    events: List[DamageEvent] = field(default_factory=list)
+    time: float = 0.0
+
+    def accumulate(self, loads: Dict[str, float], dt: float) -> None:
+        self.time += dt
+        for uid, stress in loads.items():
+            bone = self.bones.get(uid)
+            if bone is None:
+                continue
+            yield_strength = bone.material.get("yield_strength", 1e6)
+            ult_strength = bone.material.get("ultimate_strength", 2e6)
+            if stress > yield_strength:
+                severity = 0.1 if stress < ult_strength else 1.0
+                self.events.append(DamageEvent(uid, severity, self.time))

--- a/docs/round6_neural_heal.md
+++ b/docs/round6_neural_heal.md
@@ -1,0 +1,14 @@
+# Round 6 Neural and Healing Overview
+
+This round introduces a minimal neuro-sensory layer, damage detection and a bone
+healing placeholder. Sensors can be attached to muscles or joints to detect
+stretch, tension and pain. The `NeuroAgent` aggregates these signals and
+produces simple reflex activations that add to the voluntary control stream.
+
+A tiny `DamageEngine` flags bones that exceed material limits and a
+`HealingEngine` gradually restores strength over six simulated weeks.  Pain and
+fatigue reduce voluntary activation via the `PainFatigueModel`.  An
+`AutonomicAgent` adjusts basal energy based on core temperature.
+
+The implementation is intentionally simple yet sufficient for lightweight unit
+tests and CI demos.

--- a/healing/__init__.py
+++ b/healing/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['HealingEngine']

--- a/healing/healing_engine.py
+++ b/healing/healing_engine.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict
+
+
+@dataclass
+class HealingState:
+    progress: float = 0.0
+    last_update: float = 0.0
+
+
+@dataclass
+class HealingEngine:
+    """Very small bone healing model."""
+
+    bones: Dict[str, "BoneSpec"]
+    states: Dict[str, HealingState] = field(default_factory=dict)
+    time: float = 0.0
+
+    def start_healing(self, uid: str) -> None:
+        self.states[uid] = HealingState(progress=0.0, last_update=self.time)
+
+    def update(self, dt: float) -> None:
+        self.time += dt
+        for uid, state in list(self.states.items()):
+            elapsed = self.time - state.last_update
+            state.progress = min(1.0, state.progress + elapsed / (6 * 7 * 24 * 3600))
+            state.last_update = self.time
+            bone = self.bones.get(uid)
+            if bone is not None:
+                base_E = bone.material.get("E_base", 1.0)
+                bone.material["E"] = base_E * (0.2 + 0.8 * state.progress)
+            if state.progress >= 1.0:
+                del self.states[uid]

--- a/neuro/__init__.py
+++ b/neuro/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['NeuroAgent', 'PainFatigueModel']

--- a/neuro/neuro_agent.py
+++ b/neuro/neuro_agent.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, List
+
+from sensors.sensor_agent import SensorAgent
+
+
+@dataclass
+class NeuroAgent:
+    """Integrate afferent firing and apply spinal reflexes."""
+
+    sensors: List[SensorAgent] = field(default_factory=list)
+    reflex_commands: Dict[str, float] = field(default_factory=dict)
+
+    def stretch_reflex(self) -> None:
+        for s in self.sensors:
+            if s.spec.type == "muscle_spindle" and s.muscle is not None:
+                if s.firing_hz > 0.0:
+                    self.reflex_commands[s.muscle.spec.name] = self.reflex_commands.get(s.muscle.spec.name, 0.0) + 0.1 * s.firing_hz
+
+    def gto_inhibition(self) -> None:
+        for s in self.sensors:
+            if s.spec.type == "GTO" and s.muscle is not None:
+                if s.firing_hz > 0.0:
+                    self.reflex_commands[s.muscle.spec.name] = self.reflex_commands.get(s.muscle.spec.name, 0.0) - 0.1 * s.firing_hz
+
+    def withdrawal_reflex(self) -> None:
+        for s in self.sensors:
+            if s.spec.type == "nociceptor" and s.muscle is not None:
+                if s.firing_hz > 0.0:
+                    self.reflex_commands[s.muscle.spec.name] = self.reflex_commands.get(s.muscle.spec.name, 0.0) + 0.2 * s.firing_hz
+
+    def step(self, dt: float) -> Dict[str, float]:
+        self.reflex_commands.clear()
+        for s in self.sensors:
+            s.update(dt)
+        self.stretch_reflex()
+        self.gto_inhibition()
+        self.withdrawal_reflex()
+        return dict(self.reflex_commands)

--- a/neuro/pain_fatigue.py
+++ b/neuro/pain_fatigue.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class PainFatigueModel:
+    """Map nociceptor activity and fatigue to activation efficiency."""
+
+    pain: float = 0.0  # 0-10 scale
+    fatigue: float = 0.0  # 0-1 scale
+
+    def activation_efficiency(self, cmd: float, ignore_pain: bool = False, ignore_fatigue: bool = False) -> float:
+        pain_factor = 1.0
+        if not ignore_pain:
+            pain_factor = max(0.0, 1.0 - 0.05 * self.pain)
+        fat_factor = 1.0
+        if not ignore_fatigue:
+            fat_factor = max(0.0, 1.0 - 0.5 * self.fatigue)
+        return cmd * pain_factor * fat_factor

--- a/sensors/__init__.py
+++ b/sensors/__init__.py
@@ -1,0 +1,1 @@
+__all__ = ['ReceptorSpec']

--- a/sensors/receptor_spec.py
+++ b/sensors/receptor_spec.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+
+@dataclass
+class ReceptorSpec:
+    """Configuration for a single sensory receptor."""
+
+    name: str
+    type: str  # 'muscle_spindle', 'GTO', 'nociceptor', 'joint_capsule'
+    threshold: float
+    location: Dict[str, str]
+    signal_gain: float = 1.0

--- a/sensors/sensor_agent.py
+++ b/sensors/sensor_agent.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .receptor_spec import ReceptorSpec
+
+
+@dataclass
+class SensorAgent:
+    """Simplified proprioceptive/nociceptive sensor."""
+
+    spec: ReceptorSpec
+    muscle: Optional["MuscleAgent"] = None
+    physics: Optional["PhysicsAgent"] = None
+    joint_name: Optional[str] = None
+    firing_hz: float = 0.0
+    prev_angle: float = 0.0
+
+    def update(self, dt: float) -> float:
+        """Update firing rate based on stretch, tension or damage."""
+        signal = 0.0
+        if self.spec.type == "muscle_spindle" and self.joint_name and self.physics:
+            angle = self.physics.get_joint_state(self.joint_name)
+            vel = (angle - self.prev_angle) / dt
+            self.prev_angle = angle
+            strain = abs(vel)
+            signal = max(0.0, strain - self.spec.threshold) * self.spec.signal_gain
+        elif self.spec.type == "GTO" and self.muscle is not None:
+            tension = getattr(self.muscle, "last_torque", 0.0) / max(self.muscle.moment_arm_m, 1e-6)
+            signal = max(0.0, tension - self.spec.threshold) * self.spec.signal_gain
+        elif self.spec.type == "nociceptor" and self.muscle is not None:
+            dmg = getattr(self.muscle, "damage_ratio", 0.0)
+            signal = dmg * self.spec.signal_gain
+        self.firing_hz = signal
+        return self.firing_hz

--- a/soft/muscle_agent.py
+++ b/soft/muscle_agent.py
@@ -17,6 +17,7 @@ class MuscleAgent:
 
     length_m: float = 0.0
     velocity_m_s: float = 0.0
+    last_torque: float = 0.0
 
     def update(self, dt: float, activation: Optional[float] = None) -> float:
         """Return torque to apply at the joint."""
@@ -26,4 +27,5 @@ class MuscleAgent:
         f_iso = self.spec.max_isometric_force_N
         force = self.spec.activation * f_iso
         torque = force * self.moment_arm_m
+        self.last_torque = torque
         return torque

--- a/tests/test_round6_neuro_heal.py
+++ b/tests/test_round6_neuro_heal.py
@@ -1,0 +1,86 @@
+import numpy as np
+
+from skeleton.bones import load_bones
+from geometry.geometry_agent import GeometryAgent
+from joints.joint_spec import hinge
+from kinematics.kinematic_chain import KinematicChain
+from physics.physics_agent import PhysicsAgent
+from soft.muscle_spec import MuscleSpec
+from soft.muscle_agent import MuscleAgent
+from control.control_agent import ControlAgent
+from sensors.receptor_spec import ReceptorSpec
+from sensors.sensor_agent import SensorAgent
+from neuro.neuro_agent import NeuroAgent
+from neuro.pain_fatigue import PainFatigueModel
+from damage.damage_engine import DamageEngine
+from healing.healing_engine import HealingEngine
+
+
+def build_simple_elbow():
+    bones = load_bones("female_21_baseline")
+    hum = next(b for b in bones if b.unique_id == "BONE_HUMERUS_L")
+    ulna = next(b for b in bones if b.unique_id == "BONE_ULNA_L")
+    for b in (hum, ulna):
+        b.set_material("organic")
+        b.set_embodiment("physical", b.material)
+        GeometryAgent(b).compute()
+    j = hinge("elbow", hum.unique_id, ulna.unique_id, axis=(1,0,0), limit=(-180,0), origin_xyz=(0,0,hum.dimensions.get("length_cm",30)/100))
+    chain = KinematicChain({hum.unique_id: hum, ulna.unique_id: ulna}, [j], hum.unique_id)
+    muscle = MuscleAgent(MuscleSpec("biceps", {"bone_uid": hum.unique_id}, {"bone_uid": ulna.unique_id}, 300.0, 10.0, 10.0), "elbow", 0.03)
+    agent = PhysicsAgent(chain, muscles=[muscle], controller=None)
+    return agent, muscle
+
+
+def test_sensor_firing():
+    agent, muscle = build_simple_elbow()
+    rec = ReceptorSpec("s", "muscle_spindle", 0.1, {"bone_uid": muscle.spec.name})
+    sensor = SensorAgent(rec, muscle=muscle, physics=agent, joint_name="elbow")
+    agent.step(1/240)
+    f1 = sensor.update(1/240)
+    agent.step(1/240)
+    f2 = sensor.update(1/240)
+    assert f2 >= 0.0
+
+
+def test_stretch_reflex():
+    agent, muscle = build_simple_elbow()
+    spindle = SensorAgent(ReceptorSpec("sp","muscle_spindle",0.0,{"bone_uid":""},1.0), muscle=muscle, physics=agent, joint_name="elbow")
+    neuro = NeuroAgent([spindle])
+    agent.neuro = neuro
+    ctrl = ControlAgent([muscle.spec.name])
+    agent.controller = ctrl
+    spindle.firing_hz = 5.0
+    neuro.stretch_reflex()
+    torque = muscle.update(1/240, neuro.reflex_commands.get(muscle.spec.name, 0.0))
+    assert torque > 0.0
+
+
+def test_withdrawal_reflex():
+    agent, muscle = build_simple_elbow()
+    noc = SensorAgent(ReceptorSpec("n","nociceptor",0.0,{"bone_uid":""},1.0), muscle=muscle)
+    neuro = NeuroAgent([noc])
+    agent.neuro = neuro
+    muscle.damage_ratio = 1.0
+    reflex = neuro.step(1/240)
+    assert reflex[muscle.spec.name] > 0.0
+
+
+def test_pain_limits_force():
+    model = PainFatigueModel(pain=8.0, fatigue=0.0)
+    eff = model.activation_efficiency(1.0)
+    assert eff < 0.7
+
+
+def test_damage_event_and_heal():
+    agent, muscle = build_simple_elbow()
+    dmg = DamageEngine({b.unique_id: b for b in agent.chain.bones.values()})
+    heal = HealingEngine({b.unique_id: b for b in agent.chain.bones.values()})
+    agent.damage = dmg
+    agent.healing = heal
+    loads = {muscle.spec.name: 2e6}
+    dmg.accumulate({"BONE_ULNA_L":2e6}, 0.01)
+    heal.start_healing("BONE_ULNA_L")
+    for _ in range(10):
+        heal.update(6*7*24*3600/10)
+    bone = agent.chain.bones["BONE_ULNA_L"]
+    assert bone.material.get("E",0.0) >= bone.material.get("E_base",1.0)*0.8


### PR DESCRIPTION
## Summary
- implement ReceptorSpec and SensorAgent
- create NeuroAgent with reflex arcs and PainFatigue model
- add DamageEngine, HealingEngine and AutonomicAgent
- extend PhysicsAgent to integrate neural and healing systems
- add CLI demos and documentation
- add round6 tests and update CI to upload demo artifacts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685c0630bef48324a42c553202d1a618