### PR TITLE
Enhance round10 control and safety features

### DIFF
--- a/cloud/twin_sync.py
+++ b/cloud/twin_sync.py
@@ -15,15 +15,21 @@ class CloudTwinSync:
     recv_state: callable
     last_hash: str = field(init=False, default="")
     rtt_ms: float = field(init=False, default=0.0)
+    degraded: bool = field(init=False, default=False)
 
     def step(self) -> None:
         start = time.time()
         local = self.get_local_state()
         remote = self.recv_state()
-        diff = {
-            k: v for k, v in local.items() if remote.get(k) != v
-        }
+        diff = {k: v for k, v in local.items() if remote.get(k) != v}
         if diff:
             self.send_state(diff)
         self.rtt_ms = (time.time() - start) * 1000
         self.last_hash = str(hash(json.dumps(local, sort_keys=True)))
+        if self.rtt_ms > 200:
+            self.degraded = True
+        else:
+            if self.degraded:
+                # resynchronise by sending full state
+                self.send_state(local)
+            self.degraded = False

--- a/docs/compliance_doc_gen.py
+++ b/docs/compliance_doc_gen.py
@@ -4,6 +4,8 @@ import json
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any
+from reportlab.lib.pagesizes import letter
+from reportlab.pdfgen import canvas
 
 
 @dataclass
@@ -15,9 +17,14 @@ class ComplianceDocGen:
     out_pdf: Path
 
     def generate(self) -> None:
-        # Simplified placeholder: write combined json to pdf placeholder
         data: Dict[str, Any] = {
             "risk": self.risk_yaml.read_text(),
             "tests": json.loads(self.test_log.read_text()),
         }
-        self.out_pdf.write_text(json.dumps(data, indent=2))
+        c = canvas.Canvas(str(self.out_pdf), pagesize=letter)
+        text = c.beginText(50, 750)
+        for key, val in data.items():
+            text.textLine(f"{key}: {val}")
+        c.drawText(text)
+        c.showPage()
+        c.save()

--- a/tests/test_cloud_failover.py
+++ b/tests/test_cloud_failover.py
@@ -1,4 +1,5 @@
 from cloud.twin_sync import CloudTwinSync
+import time
 
 
 def test_cloud_failover():
@@ -13,6 +14,14 @@ def test_cloud_failover():
     def recv_state():
         return {}
 
+    def recv_state_delayed():
+        time.sleep(0.25)
+        return {}
+
     sync = CloudTwinSync(get_local, send_state, recv_state)
     sync.step()
-    assert sync.last_hash
+    assert not sync.degraded
+    # simulate high latency
+    sync.recv_state = recv_state_delayed
+    sync.step()
+    assert sync.degraded

--- a/tests/test_estop_chain.py
+++ b/tests/test_estop_chain.py
@@ -16,4 +16,9 @@ def test_estop_chain():
     ctrl.trigger_estop()
     time.sleep(0.05)
     ctrl.stop()
-    assert flags["estop"] and flags["torque"] == 0.0
+    assert (
+        flags["estop"]
+        and flags["torque"] == 0.0
+        and not ctrl.contactor_a
+        and not ctrl.contactor_b
+    )

--- a/tests/test_rt_watchdog.py
+++ b/tests/test_rt_watchdog.py
@@ -3,10 +3,16 @@ import time
 
 
 def test_rt_watchdog():
-    ctrl = RTControllerPy(1.0)
+    ctrl = RTControllerPy(1.0, watchdog_ms=2)
     ctrl.set_desired([0.5])
     ctrl.start()
-    time.sleep(0.003)
+    time.sleep(0.002)
+    ctrl.pause_for(0.006)
+    for _ in range(10):
+        time.sleep(0.002)
+        if ctrl.faulted:
+            break
     cmd = ctrl.command[0]
+    faulted = ctrl.faulted
     ctrl.stop()
-    assert abs(cmd - 0.5) < 1e-6
+    assert faulted and cmd == 0.0


### PR DESCRIPTION
## Summary
- add latency watchdog to RTController with pause injection
- add failover handling to CloudTwinSync
- extend safety controller with contactor outputs
- generate compliance doc PDF via reportlab
- update tests for new features

## Testing
- `pytest tests/test_hal_mock.py::test_hal_mock tests/test_rt_watchdog.py::test_rt_watchdog tests/test_estop_chain.py::test_estop_chain tests/test_cert_rotation.py::test_cert_rotation tests/test_cloud_failover.py::test_cloud_failover tests/test_tcf_generation.py::test_tcf_generation -q`

------
https://chatgpt.com/codex/tasks/task_e_685da404ea9c8324b9a276d50eb6b50b