### PR TITLE
Fix TCF generator path

### DIFF
--- a/bin/generate_tcf.py
+++ b/bin/generate_tcf.py
@@ -1,7 +1,13 @@
 #!/usr/bin/env python
-from docs.compliance_doc_gen import ComplianceDocGen
 from pathlib import Path
 import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.append(str(ROOT))
+
+from docs.compliance_doc_gen import ComplianceDocGen
 
 
 def main() -> None:

--- a/bin/generate_tcf.py
+++ b/bin/generate_tcf.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python
 
+import sys
 from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parent.parent / "docs"))
-from compliance_doc_gen import ComplianceDocGen
 import json
-import sys
+from compliance_doc_gen import ComplianceDocGen
+
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:


### PR DESCRIPTION
## Summary
- fix path handling in `generate_tcf.py`
- add repository root to `sys.path` before importing compliance generator

## Testing
- `pytest -q`
- `pytest tests/test_tcf_generation.py -q`
- `python bin/generate_tcf.py`

------
https://chatgpt.com/codex/tasks/task_e_685de182a82883248b08e0e00d84386a