### PR TITLE
Add REDWOOD project overlay scaffold

### DIFF
--- a/PROJECTS/REDWOOD/PROJECT.md
+++ b/PROJECTS/REDWOOD/PROJECT.md
@@ -1,0 +1,58 @@
+# REDWOOD Project Overlay
+
+REDWOOD is a PHY-compatible project overlay for a buildable redwood, copper, and brass adult female armature.
+
+This directory must not redefine the universal PHY framework. It supplies one concrete fabrication target using PHY-compatible records, project-local materials, hardware, proportion profiles, bone guides, and offline build artifacts.
+
+## Design rule
+
+Core PHY stays universal. REDWOOD stays project-specific.
+
+Do not hard-code redwood assumptions into:
+
+- `skeleton/base.py`
+- `skeleton/schema/bone.schema.json`
+- `skeleton/bones/`
+- `BODY.md`
+- `MIND.md`
+
+Project-specific truth belongs here under `PROJECTS/REDWOOD/`.
+
+## MVP purpose
+
+The MVP should let a builder inspect each bone and understand the base sizing required to rough-cut, drill, and carve a redwood armature part while preserving anatomical proportion and PHY simulation compatibility.
+
+The builder may refine curves by eye, but the project must provide:
+
+- finished target length, width, and thickness envelopes
+- rough blank dimensions with fabrication allowance
+- grain direction
+- proximal and distal joint centers
+- hardware assignments
+- drill schedule
+- adjacent bone connections
+- simulation mass properties when enough data exists
+- explicit unknowns where data is missing
+
+## Target
+
+- adult female armature
+- age reference: 21-28
+- neutral anatomical T-pose
+- redwood primary structure
+- copper/brass pins, collars, bushings, hinge plates, washers, and spacers
+- offline fabrication and simulation use
+
+## Definition of done
+
+REDWOOD is considered MVP-ready when the project can generate or store:
+
+- `reports/REDWOOD_BUILD_BOOK.md`
+- `reports/REDWOOD_VALIDATION.md`
+- `cutlists/redwood_cut_list.csv`
+- `cutlists/drill_schedule.csv`
+- `cutlists/hardware_cut_list.csv`
+- `simulation/redwood_armature_urdf_like.json`
+- one bone guide per buildable bone or an explicit missing-data record
+
+Validation must fail if a part cannot be sized, cut, drilled, assembled, or simulated from local project data.

--- a/PROJECTS/REDWOOD/bone_guides/BONE_FEMUR_L.md
+++ b/PROJECTS/REDWOOD/bone_guides/BONE_FEMUR_L.md
@@ -1,0 +1,75 @@
+# BONE_FEMUR_L — Left Femur
+
+## Purpose
+
+Starter guide for the left femur as a REDWOOD long-bone reference. This file demonstrates the intended bone-by-bone shop format and should be regenerated or refined once project tooling reads PHY canonical bone records directly.
+
+## Finished target envelope
+
+- Finished length: `420 mm`
+- Finished width: `40 mm` MVP shaft/joint envelope placeholder
+- Finished thickness: `40 mm` MVP shaft/joint envelope placeholder
+- Target side: `left`
+- Bone class: `long_bone`
+
+## Rough redwood blank
+
+- Blank length: `430 mm`
+- Blank width: `44 mm`
+- Blank thickness: `44 mm`
+- Grain axis: `proximal_to_distal`
+- Allowance notes: `10 mm length allowance, 4 mm width/thickness allowance from long_bone_template.json`
+
+## Carving envelope
+
+- Preserve extra material around the hip head/neck and knee condyle zones until drilling and trial assembly are complete.
+- Curvature may be shaped by eye inside the finished envelope.
+- Do not reduce any joint-end section below the minimum edge-distance rule.
+- Mark a centerline along the grain before rough shaping.
+
+## Joint centers
+
+| End | Joint center | Hardware group | Drill target | Notes |
+| --- | --- | --- | --- | --- |
+| Proximal | `TBD: hip center from pelvis/hip module` | `large_primary` | `12 mm bushing OD placeholder` | Hip interface needs spherical/hinged module design. |
+| Distal | `TBD: knee center from tibia/knee module` | `large_primary` | `12 mm bushing OD placeholder` | Knee axis must align with tibia guide. |
+
+## Connections
+
+- Parent: `BONE_HIP_L / pelvis hip module`
+- Children: `BONE_TIBIA_L`, `BONE_FIBULA_L via knee module`
+- Adjacent guides: `BONE_HIP_L.md`, `BONE_TIBIA_L.md`, `BONE_PATELLA_L.md`
+
+## Hardware
+
+- Pins: `COPPER_PIN_8MM`
+- Bushings: `BRASS_BUSHING_8MM_ID_12MM_OD`
+- Washers/spacers: `BRASS_WASHER_8MM`, final spacer stack TBD
+- Hinge/plate family: `BRASS_SINGLE_AXIS_HINGE_LARGE` for knee; hip module TBD
+
+## Drill schedule
+
+| Operation | Diameter | Depth | Reference face | Notes |
+| --- | --- | --- | --- | --- |
+| `FEMUR_L_HIP_BUSHING_PILOT` | `TBD` | `TBD` | `proximal end centerline` | Validate against hip module before drilling final diameter. |
+| `FEMUR_L_KNEE_BUSHING_PILOT` | `TBD` | `TBD` | `distal end centerline` | Must align with tibia knee axis. |
+
+## Simulation fields
+
+- Approximate mass: `TBD from redwood density and carved/blank volume`
+- Center of mass: `TBD; initial estimate at 45-50% length from proximal end`
+- Joint axis: `hip TBD, knee medial-lateral`
+- Joint limits: `TBD from project joint module`
+
+## Unknowns / required follow-up
+
+- Need exact hip module geometry.
+- Need exact knee hinge axis and spacing.
+- Need measured or referenced femur width/thickness envelope for desired adult female profile.
+- Need final pin length and spacer stack.
+- Need mass/inertia calculation after blank and carved geometry are chosen.
+
+## Fabrication status
+
+- Status: `MVP_STARTER_GUIDE_NOT_FABRICATION_READY`
+- Validation notes: `Provides length and blank planning only; joint centers, drill depths, and final hardware stack remain incomplete.`

--- a/PROJECTS/REDWOOD/cutlists/drill_schedule.csv
+++ b/PROJECTS/REDWOOD/cutlists/drill_schedule.csv
@@ -1,0 +1,3 @@
+operation_id,part_id,operation,diameter_mm,depth_mm,reference_face,hardware,status,notes
+FEMUR_L_HIP_BUSHING_PILOT,BONE_FEMUR_L,pilot_drill,TBD,TBD,proximal_end_centerline,BRASS_BUSHING_8MM_ID_12MM_OD,TBD_REQUIRES_HIP_MODULE,Do not drill final diameter until hip module is designed
+FEMUR_L_KNEE_BUSHING_PILOT,BONE_FEMUR_L,pilot_drill,TBD,TBD,distal_end_centerline,BRASS_BUSHING_8MM_ID_12MM_OD,TBD_REQUIRES_KNEE_MODULE,Do not drill final diameter until knee module axis is designed

--- a/PROJECTS/REDWOOD/cutlists/hardware_cut_list.csv
+++ b/PROJECTS/REDWOOD/cutlists/hardware_cut_list.csv
@@ -1,0 +1,4 @@
+part_id,description,qty,material,used_on,status,notes
+COPPER_PIN_8MM,8 mm copper pin family,TBD,copper_c110_or_equivalent,BONE_FEMUR_L hip and knee,MVP_FAMILY_NOT_FINAL_SKU,Confirm pin length after joint module spacing
+BRASS_BUSHING_8MM_ID_12MM_OD,8 mm ID 12 mm OD brass bushing family,TBD,brass_c360_or_equivalent,BONE_FEMUR_L hip and knee,MVP_FAMILY_NOT_FINAL_SKU,Confirm bushing length after redwood section thickness
+BRASS_WASHER_8MM,8 mm brass washer spacer family,TBD,brass_c360_or_equivalent,BONE_FEMUR_L hip and knee,MVP_FAMILY_NOT_FINAL_SKU,Spacer stack TBD during joint mockup

--- a/PROJECTS/REDWOOD/cutlists/redwood_cut_list.csv
+++ b/PROJECTS/REDWOOD/cutlists/redwood_cut_list.csv
@@ -1,0 +1,2 @@
+part_id,name,qty,material,finished_length_mm,finished_width_mm,finished_thickness_mm,blank_length_mm,blank_width_mm,blank_thickness_mm,grain_axis,status,notes
+BONE_FEMUR_L,Femur Left,1,redwood_clear_vertical_grain,420,40,40,430,44,44,proximal_to_distal,MVP_STARTER_GUIDE_NOT_FABRICATION_READY,Initial demonstrator row; verify width thickness joint centers and hardware before cutting

--- a/PROJECTS/REDWOOD/hardware/bushing_catalog.json
+++ b/PROJECTS/REDWOOD/hardware/bushing_catalog.json
@@ -1,0 +1,44 @@
+{
+  "catalog_id": "redwood_bushing_catalog_mvp",
+  "project": "REDWOOD",
+  "unit": "mm",
+  "items": [
+    {
+      "part_id": "BRASS_BUSHING_3MM_ID_6MM_OD",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 3,
+      "outer_diameter_mm": 6,
+      "nominal_length_mm": 6,
+      "preferred_use": ["fingers", "toes"]
+    },
+    {
+      "part_id": "BRASS_BUSHING_4MM_ID_8MM_OD",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 4,
+      "outer_diameter_mm": 8,
+      "nominal_length_mm": 8,
+      "preferred_use": ["wrist", "ankle", "small linkages"]
+    },
+    {
+      "part_id": "BRASS_BUSHING_6MM_ID_10MM_OD",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 6,
+      "outer_diameter_mm": 10,
+      "nominal_length_mm": 12,
+      "preferred_use": ["elbow", "knee_light", "shoulder_secondary"]
+    },
+    {
+      "part_id": "BRASS_BUSHING_8MM_ID_12MM_OD",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 8,
+      "outer_diameter_mm": 12,
+      "nominal_length_mm": 14,
+      "preferred_use": ["hip_primary", "knee_primary", "shoulder_primary"]
+    }
+  ],
+  "rules": [
+    "Bushing outer diameter defines the redwood drill or ream target, not the pin diameter.",
+    "Bushings should be bedded or press fit only after test coupons confirm split resistance.",
+    "Leave extra carving mass around every bushing until final articulation is verified."
+  ]
+}

--- a/PROJECTS/REDWOOD/hardware/hinge_catalog.json
+++ b/PROJECTS/REDWOOD/hardware/hinge_catalog.json
@@ -1,0 +1,33 @@
+{
+  "catalog_id": "redwood_hinge_catalog_mvp",
+  "project": "REDWOOD",
+  "unit": "mm",
+  "items": [
+    {
+      "part_id": "BRASS_SINGLE_AXIS_HINGE_SMALL",
+      "material": "brass_c360_or_equivalent",
+      "preferred_use": ["small digits", "secondary wrist/ankle motion"],
+      "pin_family": "COPPER_PIN_3MM",
+      "bushing_family": "BRASS_BUSHING_3MM_ID_6MM_OD"
+    },
+    {
+      "part_id": "BRASS_SINGLE_AXIS_HINGE_MEDIUM",
+      "material": "brass_c360_or_equivalent",
+      "preferred_use": ["elbow", "knee light", "ankle rocker"],
+      "pin_family": "COPPER_PIN_6MM",
+      "bushing_family": "BRASS_BUSHING_6MM_ID_10MM_OD"
+    },
+    {
+      "part_id": "BRASS_SINGLE_AXIS_HINGE_LARGE",
+      "material": "brass_c360_or_equivalent",
+      "preferred_use": ["knee primary", "hip limiter", "shoulder limiter"],
+      "pin_family": "COPPER_PIN_8MM",
+      "bushing_family": "BRASS_BUSHING_8MM_ID_12MM_OD"
+    }
+  ],
+  "rules": [
+    "Hinge plates must be sized per bone envelope before final drilling.",
+    "Do not let hinge screws define structure alone; capture major loads through pins, collars, or nested wood geometry.",
+    "Hinge catalogs are MVP families, not final purchased SKUs."
+  ]
+}

--- a/PROJECTS/REDWOOD/hardware/pin_catalog.json
+++ b/PROJECTS/REDWOOD/hardware/pin_catalog.json
@@ -1,0 +1,40 @@
+{
+  "catalog_id": "redwood_pin_catalog_mvp",
+  "project": "REDWOOD",
+  "unit": "mm",
+  "items": [
+    {
+      "part_id": "COPPER_PIN_3MM",
+      "material": "copper_c110_or_equivalent",
+      "diameter_mm": 3,
+      "preferred_use": ["fingers", "toes", "small linkages"],
+      "requires_bushing": true
+    },
+    {
+      "part_id": "COPPER_PIN_4MM",
+      "material": "copper_c110_or_equivalent",
+      "diameter_mm": 4,
+      "preferred_use": ["wrist_cluster", "ankle_secondary", "small plates"],
+      "requires_bushing": true
+    },
+    {
+      "part_id": "COPPER_PIN_6MM",
+      "material": "copper_c110_or_equivalent",
+      "diameter_mm": 6,
+      "preferred_use": ["elbow", "knee_light", "shoulder_secondary", "hip_secondary"],
+      "requires_bushing": true
+    },
+    {
+      "part_id": "COPPER_PIN_8MM",
+      "material": "copper_c110_or_equivalent",
+      "diameter_mm": 8,
+      "preferred_use": ["hip_primary", "knee_primary", "shoulder_primary"],
+      "requires_bushing": true
+    }
+  ],
+  "rules": [
+    "All pin ends must be deburred.",
+    "Moving joints require a bushing or sleeve; raw pin-on-redwood is not MVP-approved.",
+    "Pin diameter must be checked against local redwood section thickness and minimum edge distance."
+  ]
+}

--- a/PROJECTS/REDWOOD/hardware/washer_spacer_catalog.json
+++ b/PROJECTS/REDWOOD/hardware/washer_spacer_catalog.json
@@ -1,0 +1,36 @@
+{
+  "catalog_id": "redwood_washer_spacer_catalog_mvp",
+  "project": "REDWOOD",
+  "unit": "mm",
+  "items": [
+    {
+      "part_id": "BRASS_WASHER_3MM",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 3,
+      "preferred_use": ["digits", "small linkages"]
+    },
+    {
+      "part_id": "BRASS_WASHER_4MM",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 4,
+      "preferred_use": ["wrist", "ankle", "small plates"]
+    },
+    {
+      "part_id": "BRASS_WASHER_6MM",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 6,
+      "preferred_use": ["elbow", "knee", "shoulder secondary"]
+    },
+    {
+      "part_id": "BRASS_WASHER_8MM",
+      "material": "brass_c360_or_equivalent",
+      "inner_diameter_mm": 8,
+      "preferred_use": ["hip", "knee primary", "shoulder primary"]
+    }
+  ],
+  "rules": [
+    "Use washers or spacers wherever moving redwood parts could rub directly.",
+    "Spacer thickness is project-specific and should be derived during joint mockup.",
+    "Document final spacer stack in each bone guide before declaring fabrication-ready."
+  ]
+}

--- a/PROJECTS/REDWOOD/materials/brass.json
+++ b/PROJECTS/REDWOOD/materials/brass.json
@@ -1,0 +1,30 @@
+{
+  "material_id": "brass_c360_or_equivalent",
+  "project": "REDWOOD",
+  "category": "bushing_plate_and_hinge_hardware",
+  "status": "mvp_placeholder_requires_reference_upgrade",
+  "canonical_units": {
+    "density": "kg/m^3",
+    "modulus": "GPa",
+    "strength": "MPa",
+    "dimension": "mm"
+  },
+  "properties": {
+    "density_kg_m3": 8500,
+    "elastic_modulus_GPa": 97,
+    "yield_strength_MPa": null,
+    "shear_strength_MPa": null
+  },
+  "fabrication_rules": {
+    "preferred_uses": ["bushings", "wear sleeves", "hinge leaves", "washers", "spacers", "threaded inserts"],
+    "moving_joint_bearing_surface": true,
+    "deburr_all_edges": true,
+    "isolate_from_raw_wood_with_epoxy_bed_when_fit_is_loose": true
+  },
+  "risk_notes": [
+    "Brass is preferred over raw wood bearing surfaces for repeated movement.",
+    "Thin hinge plates must be sized against expected torque and screw pull-out.",
+    "MVP strength fields require reference upgrade before structural certification."
+  ],
+  "source_status": "project_estimate_until_local_references_are_added"
+}

--- a/PROJECTS/REDWOOD/materials/copper.json
+++ b/PROJECTS/REDWOOD/materials/copper.json
@@ -1,0 +1,30 @@
+{
+  "material_id": "copper_c110_or_equivalent",
+  "project": "REDWOOD",
+  "category": "pin_and_accent_hardware",
+  "status": "mvp_placeholder_requires_reference_upgrade",
+  "canonical_units": {
+    "density": "kg/m^3",
+    "modulus": "GPa",
+    "strength": "MPa",
+    "dimension": "mm"
+  },
+  "properties": {
+    "density_kg_m3": 8960,
+    "elastic_modulus_GPa": 117,
+    "yield_strength_MPa": null,
+    "shear_strength_MPa": null
+  },
+  "fabrication_rules": {
+    "preferred_uses": ["visible pins", "retention collars", "decorative hardware", "low_speed_rotation_pins"],
+    "avoid_direct_wood_bearing_for_repeated_motion": true,
+    "pair_with_bushing_material": "brass_c360_or_equivalent",
+    "deburr_all_edges": true
+  },
+  "risk_notes": [
+    "Copper is visually appropriate but softer than many steels; do not assume high load capacity without calculation.",
+    "Use larger pin diameters or brass bearing sleeves where wear or repeated articulation is expected.",
+    "MVP strength fields require reference upgrade before structural certification."
+  ],
+  "source_status": "project_estimate_until_local_references_are_added"
+}

--- a/PROJECTS/REDWOOD/materials/finish_options.json
+++ b/PROJECTS/REDWOOD/materials/finish_options.json
@@ -1,0 +1,26 @@
+{
+  "finish_options_id": "redwood_finish_options_mvp",
+  "project": "REDWOOD",
+  "status": "mvp_placeholder_requires_test_coupons",
+  "options": [
+    {
+      "finish_id": "clear_oil_test_coupon",
+      "description": "Clear penetrating oil finish candidate for natural redwood appearance.",
+      "requires_test_coupon": true,
+      "notes": ["Verify darkening, tackiness, and joint-hole swelling before applying to finished parts."]
+    },
+    {
+      "finish_id": "shellac_test_coupon",
+      "description": "Shellac candidate for sealed studio/display surface.",
+      "requires_test_coupon": true,
+      "notes": ["Test for brittleness near moving joints and compatibility with brass/copper hardware."]
+    },
+    {
+      "finish_id": "unfinished_reference_coupon",
+      "description": "Unfinished redwood control coupon for dimensional movement comparison.",
+      "requires_test_coupon": true,
+      "notes": ["Keep one labeled sample in the project kit for humidity comparison."]
+    }
+  ],
+  "project_rule": "No final finish should be selected until drilled redwood, brass bushing, and copper pin coupons are tested together."
+}

--- a/PROJECTS/REDWOOD/materials/redwood.json
+++ b/PROJECTS/REDWOOD/materials/redwood.json
@@ -1,0 +1,37 @@
+{
+  "material_id": "redwood_clear_vertical_grain",
+  "project": "REDWOOD",
+  "category": "wood_structural_primary",
+  "status": "mvp_placeholder_requires_reference_upgrade",
+  "preferred_stock": "clear, straight-grained, knot-free redwood with grain running along primary load axis",
+  "canonical_units": {
+    "density": "kg/m^3",
+    "modulus": "GPa",
+    "strength": "MPa",
+    "dimension": "mm"
+  },
+  "properties": {
+    "density_kg_m3": 450,
+    "elastic_modulus_GPa": null,
+    "compressive_strength_parallel_MPa": null,
+    "bending_strength_MPa": null,
+    "shear_strength_MPa": null
+  },
+  "fabrication_rules": {
+    "grain_axis_default": "proximal_to_distal_for_long_bones",
+    "avoid_knots_at_joint_centers": true,
+    "require_bushing_for_repeated_motion": true,
+    "minimum_edge_distance_rule": "max(2 * pin_diameter_mm, 8)",
+    "rough_blank_extra_length_mm_long_bone": 10,
+    "rough_blank_extra_width_mm": 4,
+    "rough_blank_extra_thickness_mm": 4,
+    "final_sanding_target_grit": 320
+  },
+  "risk_notes": [
+    "Wood movement with humidity must be considered before final pin fit.",
+    "Moving joints should not run raw pin-on-redwood; use brass bushing, sleeve, or bearing surface.",
+    "Thin sections near drilled holes are split-prone; leave extra material around all joint ends during first carving pass.",
+    "MVP mechanical constants require reference upgrade before load-bearing use."
+  ],
+  "source_status": "project_estimate_until_local_references_are_added"
+}

--- a/PROJECTS/REDWOOD/profiles/adult_female_21_28.json
+++ b/PROJECTS/REDWOOD/profiles/adult_female_21_28.json
@@ -1,0 +1,49 @@
+{
+  "profile_id": "adult_female_21_28",
+  "status": "mvp_reference_profile",
+  "description": "Project-local adult female proportion profile for REDWOOD armature sizing. Values are base build targets and may be replaced by measured references in later passes.",
+  "pose": "neutral_anatomical_t_pose",
+  "age_reference": "21-28",
+  "height_mm": 1650,
+  "arm_span_mm": 1650,
+  "head_height_ratio": 7.5,
+  "major_widths_mm": {
+    "biacromial_shoulder_breadth": 370,
+    "pelvis_breadth": 285,
+    "ribcage_max_width": 280,
+    "waist_clearance_width": 210
+  },
+  "primary_lengths_mm": {
+    "skull_height": 220,
+    "cervical_stack": 95,
+    "thoracic_stack": 280,
+    "lumbar_stack": 170,
+    "sacrum_coccyx_stack": 125,
+    "clavicle": 140,
+    "scapula_height": 145,
+    "humerus": 310,
+    "radius": 240,
+    "ulna": 250,
+    "hand_total": 175,
+    "hip_bone_height": 230,
+    "femur": 420,
+    "tibia": 375,
+    "fibula": 355,
+    "foot_total": 240
+  },
+  "bilateral_symmetry_policy": {
+    "left_right_lengths_match_initially": true,
+    "allow_hand_carved_asymmetry_after_blank_layout": true
+  },
+  "derivation_tags": {
+    "height_mm": "project_design_decision",
+    "arm_span_mm": "vitruvian_ratio_height_equals_armspan",
+    "primary_lengths_mm": "baseline_anthropometric_targets_for_mvp",
+    "major_widths_mm": "baseline_anthropometric_targets_for_mvp"
+  },
+  "notes": [
+    "This file sets REDWOOD project targets only; it does not change universal PHY proportions.",
+    "Exact curvature is intentionally left to carving guides and builder judgment; this profile supplies base envelopes and length targets.",
+    "Later passes should replace or cite each MVP target with traceable measured or published anthropometric references."
+  ]
+}

--- a/PROJECTS/REDWOOD/profiles/proportion_rules.json
+++ b/PROJECTS/REDWOOD/profiles/proportion_rules.json
@@ -1,0 +1,43 @@
+{
+  "rule_set_id": "redwood_mvp_proportion_rules",
+  "purpose": "Describe how REDWOOD project measurements are derived without changing universal PHY data.",
+  "unit": "mm",
+  "rules": [
+    {
+      "rule_id": "arm_span_equals_height",
+      "expression": "arm_span_mm = height_mm",
+      "source_type": "proportion_rule",
+      "notes": "Vitruvian working target for neutral T-pose layout."
+    },
+    {
+      "rule_id": "rough_blank_allowance_long_bone",
+      "expression": "blank_length_mm = finished_length_mm + 10",
+      "source_type": "fabrication_allowance",
+      "notes": "Initial 5 mm end allowance per side for trimming, squaring, and hand carving."
+    },
+    {
+      "rule_id": "rough_blank_allowance_small_bone",
+      "expression": "blank_length_mm = finished_length_mm + 4",
+      "source_type": "fabrication_allowance",
+      "notes": "Small bones need smaller trimming allowance to avoid excessive waste."
+    },
+    {
+      "rule_id": "grain_axis_long_bone",
+      "expression": "grain_axis = proximal_to_distal",
+      "source_type": "material_orientation_rule",
+      "notes": "Long grain follows load path through limb bones."
+    },
+    {
+      "rule_id": "minimum_pin_edge_distance",
+      "expression": "minimum_edge_distance_mm >= max(2 * pin_diameter_mm, 8)",
+      "source_type": "fabrication_safety_rule",
+      "notes": "MVP rule to keep drilled pin holes from splitting redwood near joint ends."
+    },
+    {
+      "rule_id": "bushing_preferred_at_moving_joints",
+      "expression": "moving_joint_requires_bushing = true",
+      "source_type": "hardware_design_rule",
+      "notes": "Brass bushings prevent copper/brass pins from wallowing redwood holes during repeated motion."
+    }
+  ]
+}

--- a/PROJECTS/REDWOOD/project.config.json
+++ b/PROJECTS/REDWOOD/project.config.json
@@ -1,0 +1,48 @@
+{
+  "project_id": "REDWOOD",
+  "phy_compatibility": "1.0",
+  "project_type": "fabrication_overlay",
+  "core_rule": "Do not hard-code REDWOOD-specific assumptions into the universal PHY framework.",
+  "target": {
+    "type": "adult_female_armature",
+    "age_reference": "21-28",
+    "pose": "neutral_anatomical_t_pose",
+    "proportion_profile": "profiles/adult_female_21_28.json",
+    "primary_build_goal": "bone_by_bone_redwood_cut_carve_drill_guidance"
+  },
+  "materials": {
+    "primary_structure": "materials/redwood.json",
+    "pin_material": "materials/copper.json",
+    "bushing_and_plate_material": "materials/brass.json"
+  },
+  "hardware_catalogs": [
+    "hardware/pin_catalog.json",
+    "hardware/bushing_catalog.json",
+    "hardware/hinge_catalog.json",
+    "hardware/washer_spacer_catalog.json"
+  ],
+  "templates": {
+    "bone_guide": "templates/bone_guide_template.md",
+    "long_bone": "templates/long_bone_template.json",
+    "flat_bone": "templates/flat_bone_template.json",
+    "small_bone": "templates/small_bone_template.json",
+    "vertebra": "templates/vertebra_template.json",
+    "rib": "templates/rib_template.json"
+  },
+  "outputs": {
+    "bone_guides": "bone_guides/",
+    "cutlists": "cutlists/",
+    "simulation": "simulation/",
+    "reports": "reports/"
+  },
+  "validation_policy": {
+    "fail_on_missing_finished_dimensions": true,
+    "fail_on_missing_blank_dimensions": true,
+    "fail_on_missing_grain_axis": true,
+    "fail_on_missing_joint_centers": true,
+    "fail_on_missing_hardware_assignment": true,
+    "fail_on_missing_drill_schedule": true,
+    "fail_on_missing_connection_map": true,
+    "allow_explicit_unknowns_in_mvp": true
+  }
+}

--- a/PROJECTS/REDWOOD/reports/REDWOOD_BUILD_BOOK.md
+++ b/PROJECTS/REDWOOD/reports/REDWOOD_BUILD_BOOK.md
@@ -1,0 +1,80 @@
+# REDWOOD Build Book
+
+Status: `MVP_SCAFFOLD_CREATED`
+
+This build book is the project-local offline packet for the REDWOOD armature. It is intentionally incomplete at scaffold time, but defines the exact sections required for a complete offline build.
+
+## 1. Project identity
+
+REDWOOD is a PHY-compatible project overlay for an adult female redwood armature using copper and brass hardware.
+
+## 2. Build doctrine
+
+Measure twice, cut once.
+
+- Use PHY for universal skeleton records.
+- Use REDWOOD for project-specific material, proportion, hardware, cut, drill, and assembly decisions.
+- Do not treat poetic or symbolic continuity as fabrication truth.
+- Do not final-cut any part marked `TBD` or `MVP_STARTER_GUIDE_NOT_FABRICATION_READY`.
+
+## 3. Materials
+
+- Primary structure: `materials/redwood.json`
+- Pins/accent hardware: `materials/copper.json`
+- Bushings/plates/washers/spacers: `materials/brass.json`
+- Finish candidates: `materials/finish_options.json`
+
+## 4. Hardware catalogs
+
+- `hardware/pin_catalog.json`
+- `hardware/bushing_catalog.json`
+- `hardware/hinge_catalog.json`
+- `hardware/washer_spacer_catalog.json`
+
+## 5. Proportion profile
+
+- `profiles/adult_female_21_28.json`
+- `profiles/proportion_rules.json`
+
+## 6. Bone guides
+
+Bone guides live in `bone_guides/`.
+
+Current starter guide:
+
+- `bone_guides/BONE_FEMUR_L.md`
+
+Required next guides:
+
+- major long bones
+- pelvis/hip modules
+- shoulder suspension module
+- spine and rib modules
+- hand/foot simplified MVP modules
+
+## 7. Cut lists
+
+- `cutlists/redwood_cut_list.csv`
+- `cutlists/hardware_cut_list.csv`
+- `cutlists/drill_schedule.csv`
+
+## 8. Simulation outputs
+
+Simulation artifacts will live in `simulation/` once generated.
+
+Required future artifacts:
+
+- `simulation/redwood_armature_urdf_like.json`
+- `simulation/joint_limits.json`
+- `simulation/mass_properties.json`
+- `simulation/collision_primitives.json`
+
+## 9. Current hard stop
+
+This scaffold is not yet a complete fabrication packet.
+
+Only `BONE_FEMUR_L` has a starter guide, and it still contains TBDs for joint modules, drill depths, joint centers, and final hardware lengths.
+
+## 10. Next build step
+
+Create REDWOOD project tooling that reads universal PHY records, applies REDWOOD templates, and generates per-bone guides plus project cut lists without modifying PHY core.

--- a/PROJECTS/REDWOOD/reports/REDWOOD_VALIDATION.md
+++ b/PROJECTS/REDWOOD/reports/REDWOOD_VALIDATION.md
@@ -1,0 +1,41 @@
+# REDWOOD Validation Report
+
+Status: `MVP_SCAFFOLD_CREATED`
+
+## Scope
+
+This report tracks the REDWOOD project overlay only. It does not validate or alter universal PHY core files.
+
+## Current pass
+
+- Project config exists: yes
+- Adult female 21-28 profile exists: yes
+- Redwood material profile exists: yes
+- Copper material profile exists: yes
+- Brass material profile exists: yes
+- Hardware catalogs exist: yes
+- Bone guide template exists: yes
+- Fabrication class templates exist: yes
+- Starter femur guide exists: yes
+- Initial cut lists exist: yes
+
+## Known failures / incomplete data
+
+- Most bones do not yet have generated REDWOOD bone guides.
+- Most bones do not yet have project-local blank dimensions.
+- Joint centers are not yet generated from project joint modules.
+- Drill schedule is demonstrator-only for `BONE_FEMUR_L`.
+- Hardware items are MVP families, not final purchased SKUs.
+- Material strength fields need local references or verified material datasheets.
+- Anthropometric targets are MVP project targets and need reference upgrades.
+- Simulation mass/inertia outputs are not yet generated.
+
+## Next required pass
+
+1. Add a project overlay loader or generator that reads PHY bone records and REDWOOD templates.
+2. Generate long-bone guides for femur, tibia, fibula, humerus, radius, ulna, and clavicle.
+3. Normalize parent/child names into project-local connection IDs.
+4. Add shoulder, hip, knee, elbow, wrist, ankle, hand, foot, spine, and rib module files.
+5. Replace placeholder material constants with referenced local-source records.
+6. Generate complete cut lists and drill schedule.
+7. Generate simulation mass properties and URDF-like project artifact.

--- a/PROJECTS/REDWOOD/templates/bone_guide_template.md
+++ b/PROJECTS/REDWOOD/templates/bone_guide_template.md
@@ -1,0 +1,69 @@
+# {{bone_id}} — {{bone_name}}
+
+## Purpose
+
+This guide converts a PHY-compatible bone record into shop-floor guidance for the REDWOOD armature.
+
+## Finished target envelope
+
+- Finished length: `{{finished_length_mm}} mm`
+- Finished width: `{{finished_width_mm}} mm`
+- Finished thickness: `{{finished_thickness_mm}} mm`
+- Target side: `{{side}}`
+- Bone class: `{{bone_class}}`
+
+## Rough redwood blank
+
+- Blank length: `{{blank_length_mm}} mm`
+- Blank width: `{{blank_width_mm}} mm`
+- Blank thickness: `{{blank_thickness_mm}} mm`
+- Grain axis: `{{grain_axis}}`
+- Allowance notes: `{{allowance_notes}}`
+
+## Carving envelope
+
+- Preserve extra material around all joint centers until drilling and trial assembly are complete.
+- Curvature may be shaped by eye inside the finished envelope.
+- Do not reduce any joint-end section below the minimum edge-distance rule.
+
+## Joint centers
+
+| End | Joint center | Hardware group | Drill target | Notes |
+| --- | --- | --- | --- | --- |
+| Proximal | `{{proximal_joint_center_mm}}` | `{{proximal_hardware_group}}` | `{{proximal_drill_target_mm}}` | `{{proximal_notes}}` |
+| Distal | `{{distal_joint_center_mm}}` | `{{distal_hardware_group}}` | `{{distal_drill_target_mm}}` | `{{distal_notes}}` |
+
+## Connections
+
+- Parent: `{{parent_connection}}`
+- Children: `{{child_connections}}`
+- Adjacent guides: `{{adjacent_guides}}`
+
+## Hardware
+
+- Pins: `{{pins}}`
+- Bushings: `{{bushings}}`
+- Washers/spacers: `{{washers_spacers}}`
+- Hinge/plate family: `{{hinge_family}}`
+
+## Drill schedule
+
+| Operation | Diameter | Depth | Reference face | Notes |
+| --- | --- | --- | --- | --- |
+| `{{operation_id}}` | `{{diameter_mm}} mm` | `{{depth_mm}} mm` | `{{reference_face}}` | `{{operation_notes}}` |
+
+## Simulation fields
+
+- Approximate mass: `{{mass_kg}} kg`
+- Center of mass: `{{center_of_mass_mm}}`
+- Joint axis: `{{joint_axis}}`
+- Joint limits: `{{joint_limits_deg}}`
+
+## Unknowns / required follow-up
+
+- `{{unknowns}}`
+
+## Fabrication status
+
+- Status: `{{fabrication_status}}`
+- Validation notes: `{{validation_notes}}`

--- a/PROJECTS/REDWOOD/templates/flat_bone_template.json
+++ b/PROJECTS/REDWOOD/templates/flat_bone_template.json
@@ -1,0 +1,21 @@
+{
+  "template_id": "redwood_flat_bone_mvp",
+  "applies_to": ["scapula", "hip_bone", "sternum", "cranial_plate"],
+  "material": "redwood_clear_vertical_grain",
+  "grain_axis": "dominant_load_or_longest_axis",
+  "blank_allowance_mm": {
+    "length": 8,
+    "width": 8,
+    "thickness": 4
+  },
+  "joint_mount_policy": {
+    "use_plate_or_bushing_where_motion_occurs": true,
+    "avoid_thin_drilled_tabs": true,
+    "minimum_edge_distance_rule": "max(2 * pin_diameter_mm, 8)"
+  },
+  "carving_guidance": [
+    "Lay out a flat reference face before sculpting surface curvature.",
+    "Leave broad pads where straps, plates, or bushings attach.",
+    "Shape visible elegance after mounting faces and joint centers are stable."
+  ]
+}

--- a/PROJECTS/REDWOOD/templates/long_bone_template.json
+++ b/PROJECTS/REDWOOD/templates/long_bone_template.json
@@ -1,0 +1,39 @@
+{
+  "template_id": "redwood_long_bone_mvp",
+  "applies_to": ["femur", "tibia", "fibula", "humerus", "radius", "ulna", "clavicle"],
+  "material": "redwood_clear_vertical_grain",
+  "grain_axis": "proximal_to_distal",
+  "blank_allowance_mm": {
+    "length": 10,
+    "width": 4,
+    "thickness": 4
+  },
+  "joint_end_policy": {
+    "leave_extra_mass_until_trial_fit": true,
+    "minimum_edge_distance_rule": "max(2 * pin_diameter_mm, 8)",
+    "moving_joint_requires_bushing": true
+  },
+  "default_hardware_groups": {
+    "large_primary": {
+      "pin": "COPPER_PIN_8MM",
+      "bushing": "BRASS_BUSHING_8MM_ID_12MM_OD",
+      "washer": "BRASS_WASHER_8MM"
+    },
+    "medium_primary": {
+      "pin": "COPPER_PIN_6MM",
+      "bushing": "BRASS_BUSHING_6MM_ID_10MM_OD",
+      "washer": "BRASS_WASHER_6MM"
+    },
+    "small_primary": {
+      "pin": "COPPER_PIN_4MM",
+      "bushing": "BRASS_BUSHING_4MM_ID_8MM_OD",
+      "washer": "BRASS_WASHER_4MM"
+    }
+  },
+  "carving_guidance": [
+    "Rough cut oversized and square before marking joint centers.",
+    "Mark centerline along grain before shaping.",
+    "Drill bushing holes before final organic contouring.",
+    "Preserve enough redwood around each bushing for the minimum edge-distance rule."
+  ]
+}

--- a/PROJECTS/REDWOOD/templates/rib_template.json
+++ b/PROJECTS/REDWOOD/templates/rib_template.json
@@ -1,0 +1,22 @@
+{
+  "template_id": "redwood_rib_mvp",
+  "applies_to": ["rib"],
+  "material": "redwood_clear_vertical_grain",
+  "grain_axis": "along_rib_arc_where_possible",
+  "blank_allowance_mm": {
+    "length": 8,
+    "width": 3,
+    "thickness": 3
+  },
+  "fabrication_policy": {
+    "allow_laminated_or_steam_bent_strategy": true,
+    "allow_simplified_arc_for_mvp": true,
+    "sternum_attachment_requires_documented_mount": true,
+    "spine_attachment_requires_documented_mount": true
+  },
+  "carving_guidance": [
+    "Ribs are thin and split-prone; avoid drilling close to ends without reinforcement.",
+    "For MVP, use consistent arcs and labeled left/right rib order before chasing perfect anatomical curvature.",
+    "Consider lamination or bent stock where straight-grain carving would cut across too much grain."
+  ]
+}

--- a/PROJECTS/REDWOOD/templates/small_bone_template.json
+++ b/PROJECTS/REDWOOD/templates/small_bone_template.json
@@ -1,0 +1,22 @@
+{
+  "template_id": "redwood_small_bone_mvp",
+  "applies_to": ["carpal", "tarsal", "metacarpal", "metatarsal", "phalange", "ossicle"],
+  "material": "redwood_clear_vertical_grain",
+  "grain_axis": "longest_axis_where_visible_or_structural",
+  "blank_allowance_mm": {
+    "length": 4,
+    "width": 2,
+    "thickness": 2
+  },
+  "hardware_policy": {
+    "default_pin": "COPPER_PIN_3MM",
+    "default_bushing": "BRASS_BUSHING_3MM_ID_6MM_OD",
+    "allow_fixed_dummy_joint_for_nonfunctional_mvp": true,
+    "minimum_edge_distance_rule": "max(2 * pin_diameter_mm, 8)"
+  },
+  "carving_guidance": [
+    "Small bones may be grouped into simplified functional clusters during MVP if individual articulation is not required.",
+    "Mark left/right and digit index before cutting.",
+    "Prefer conservative oversized blanks for hand finishing."
+  ]
+}

--- a/PROJECTS/REDWOOD/templates/vertebra_template.json
+++ b/PROJECTS/REDWOOD/templates/vertebra_template.json
@@ -1,0 +1,21 @@
+{
+  "template_id": "redwood_vertebra_mvp",
+  "applies_to": ["cervical_vertebra", "thoracic_vertebra", "lumbar_vertebra", "sacrum", "coccyx"],
+  "material": "redwood_clear_vertical_grain",
+  "grain_axis": "superior_to_inferior_or_laminate_per_stack_design",
+  "blank_allowance_mm": {
+    "height": 3,
+    "width": 4,
+    "thickness": 4
+  },
+  "stack_policy": {
+    "allow_simplified_spacer_stack_for_mvp": true,
+    "moving_segments_require_spacer_or_bushing": true,
+    "document_stack_order": true
+  },
+  "carving_guidance": [
+    "Keep a flat superior and inferior registration face until the spine stack is aligned.",
+    "Organic processes may be simplified unless required for visual fidelity or cable routing.",
+    "Do not final-round mating faces until full spine spacing is checked."
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a non-invasive `PROJECTS/REDWOOD/` overlay for a redwood, copper, and brass adult female armature build target while preserving the universal PHY framework.

This PR intentionally does **not** modify core PHY files such as `skeleton/base.py`, `skeleton/schema/bone.schema.json`, `BODY.md`, or `MIND.md`.

## What changed

- Added `PROJECTS/REDWOOD/PROJECT.md` to define project scope, boundaries, and MVP definition.
- Added `project.config.json` for PHY-compatible overlay metadata and validation policy.
- Added adult female 21-28 proportion profile and derivation rules.
- Added project-local material profiles for redwood, copper, brass, and finish test options.
- Added hardware catalogs for pins, bushings, hinge families, washers, and spacers.
- Added fabrication templates for long bones, flat bones, small bones, vertebrae, ribs, and a generic bone guide.
- Added starter `BONE_FEMUR_L` shop guide, initial cut lists, drill schedule, hardware list, validation report, and build book scaffold.

## Design intent

Core PHY remains universal. REDWOOD becomes the first project-specific offline fabrication overlay.

The MVP goal is to let a builder inspect each bone and understand:

- how large the finished part should be,
- what rough redwood blank to start from,
- grain direction,
- joint center and hardware requirements,
- drill schedule expectations,
- adjacent bone connections,
- what remains unknown before cutting.

## Current limitations

- Only `BONE_FEMUR_L` has a starter guide.
- Material constants are MVP placeholders pending referenced datasheets/local source records.
- Hardware catalogs define families, not final purchased SKUs.
- Joint centers, drill depths, mass properties, and URDF-like simulation outputs are not yet generated.
- The next pass should add project tooling that reads PHY canonical records and generates REDWOOD bone guides/cutlists without altering core PHY.

## Testing

No runtime tests were run because this PR adds project data/scaffold files only. A compare against `main` shows 24 added files under `PROJECTS/REDWOOD/` and no core framework changes.