### PR TITLE
Add T-5.6 carbon-composite frame scaffold

### DIFF
--- a/PROJECTS/README.md
+++ b/PROJECTS/README.md
@@ -16,6 +16,10 @@ Project overlays live here. Each project may define local material records, comp
 - `JUNIPER/` — juniper comparison project.
 - `CYPRESS/` — cypress and reclaimed cypress comparison project.
 
+## Composite armature projects
+
+- `T56_CARBON/` — 1676.4 mm domestic humanoid armature using hybrid carbon-composite members, replaceable metallic joint cartridges, tendon-driven distal mechanisms, and compliant artificial fascia. The current scaffold is conceptual and explicitly not fabrication-ready.
+
 ## Rule
 
 Project overlays may specialize fabrication assumptions locally. Universal PHY files remain species-agnostic.

--- a/PROJECTS/T56_CARBON/PROJECT.md
+++ b/PROJECTS/T56_CARBON/PROJECT.md
@@ -1,0 +1,101 @@
+# T-5.6 CARBON Project Overlay
+
+T-5.6 CARBON is a PHY-compatible project overlay for a 5 ft 6 in (1676.4 mm) domestic humanoid armature built around hybrid carbon-composite members, serviceable metallic joint cartridges, tendon-driven distal mechanisms, and compliant artificial fascia.
+
+This project does not redefine universal PHY anatomy or fabrication policy. It supplies one concrete embodiment target using project-local proportions, materials, interfaces, validation plans, component architecture, and simulation artifacts.
+
+## Identity
+
+- Project ID: `T56_CARBON`
+- Height: `1676.4 mm`
+- Baseline arm span: `1676.4 mm`
+- Lineage: mature domestic evolution of the utilitarian `T-5.5(5)` concept
+- Pose baseline: neutral anatomical T-pose
+- Frame class: hybrid carbon-composite armature
+- Intended environment: quiet indoor and domestic operation
+
+## Design intent
+
+T-5.6 prioritizes:
+
+- quiet movement and low vibration
+- safe close-proximity operation
+- comfortable sitting, reclining, and bedside posture
+- serviceable joints and replaceable wear components
+- high tactile-sensor density
+- guarded pinch points and compliant contact surfaces
+- adult, capable proportions without exaggerated display anatomy
+
+## Structural doctrine
+
+> Carbon carries the frame. Metal carries the joints. Tension carries the body. Softness carries the contact.
+
+- Carbon-composite members carry distributed bending and torsional loads.
+- Metallic cartridges carry bearings, threads, shafts, actuator mounts, and concentrated loads.
+- Bonded inserts use keyed geometry, generous bond length, load spreading, and secondary mechanical capture.
+- No raw bolt loads directly through unreinforced laminate.
+- No direct carbon-to-aluminum contact without a dielectric isolation layer.
+- Artificial fascia distributes tension, damps vibration, supports outer-body volume, and provides sensor attachment structure.
+
+## Architecture
+
+### Long members
+
+Femur, tibia, fibula, humerus, radius, and ulna use open or closed carbon-composite truss members. Initial prototypes may use commercial structural tubing where it reduces manufacturing uncertainty.
+
+### Torso
+
+The torso is layered:
+
+1. central spine and pelvic load path
+2. shoulder and rib structural frame
+3. actuator and electronics cradle
+4. removable carbon service panels
+5. compliant fascia and outer body
+
+### Pelvis
+
+The pelvis is not monolithic. It consists of:
+
+- central sacral load bridge
+- left and right iliac composite shells
+- separate replaceable hip cartridges
+- compliant tensile stabilization network
+
+### Hands and feet
+
+Hands use light distal linkages with tendons routed to serviceable forearm actuators. Feet use a broader hidden sole structure, pressure sensing, compliant heel/toe elements, and replaceable contact surfaces.
+
+## MVP demonstrator
+
+The first complete systems article is the left forearm:
+
+- `BONE_RADIUS_L` carbon member
+- `BONE_ULNA_L` carbon member
+- elbow and wrist cartridges
+- internal service and cable channels
+- tactile electrode segments
+- skin/fascia mount points
+- destructive coupons made from the same material, adhesive, and insert geometry
+
+## Fabrication status
+
+Status: `SCAFFOLD_NOT_FABRICATION_READY`
+
+All laminate schedules, dimensions, material constants, adhesives, insert geometries, load ratings, joint limits, and safety factors remain unvalidated until supported by traceable references and physical coupon testing.
+
+Unknown values must be marked explicitly. No fabrication-critical value may be inferred from visual concept art.
+
+## Required artifacts
+
+The project becomes MVP-ready only when it can generate or store:
+
+- complete project profile and proportion rules
+- referenced material records
+- bonded-insert and joint-cartridge specifications
+- forearm fabrication packet
+- coupon and joint validation reports
+- cutlists and drill schedules
+- mass and inertia estimates
+- URDF-like simulation output
+- service-access and cable-routing documentation

--- a/PROJECTS/T56_CARBON/components/left_forearm_demonstrator.json
+++ b/PROJECTS/T56_CARBON/components/left_forearm_demonstrator.json
@@ -1,0 +1,84 @@
+{
+  "component_id": "T56_LEFT_FOREARM_DEMONSTRATOR",
+  "project": "T56_CARBON",
+  "status": "concept_scaffold_not_fabrication_ready",
+  "purpose": "First complete systems article for validating composite members, bonded inserts, serviceable joints, wiring, tactile sensing, fascia mounts, and repairability.",
+  "phy_members": [
+    "BONE_RADIUS_L",
+    "BONE_ULNA_L"
+  ],
+  "architecture": {
+    "radius_member": {
+      "topology": "dual_rail_or_closed_truss_carbon_member",
+      "finished_length_mm": null,
+      "cross_section": null,
+      "laminate_schedule": null
+    },
+    "ulna_member": {
+      "topology": "dual_rail_or_closed_truss_carbon_member",
+      "finished_length_mm": null,
+      "cross_section": null,
+      "laminate_schedule": null
+    },
+    "elbow_interface": {
+      "type": "replaceable_metal_joint_cartridge",
+      "joint_axis": null,
+      "joint_limits_deg": null,
+      "bearing_family": null
+    },
+    "wrist_interface": {
+      "type": "replaceable_metal_joint_cartridge",
+      "joint_axes": null,
+      "joint_limits_deg": null,
+      "bearing_family": null
+    },
+    "service_channel": {
+      "minimum_clearance_mm": null,
+      "contents": [
+        "tendon or cable routing",
+        "sensor wiring",
+        "power and data segmentation",
+        "strain and temperature sensing"
+      ],
+      "access": "removable_nonstructural_cover"
+    },
+    "tactile_segments": {
+      "count": null,
+      "electrical_isolation_required": true,
+      "frame_conductivity_must_be_modeled": true
+    },
+    "fascia_mounts": {
+      "count": null,
+      "load_rating_N": null,
+      "replaceable": true
+    }
+  },
+  "insert_doctrine": [
+    "Internal inserts must use keyed anti-rotation geometry.",
+    "Bond length and local laminate reinforcement are determined by coupon and subcomponent testing.",
+    "A secondary capture feature is required so adhesive is not the sole retention mechanism.",
+    "Bearing and threaded surfaces remain replaceable without damaging the primary carbon member."
+  ],
+  "validation_sequence": [
+    "material witness coupons",
+    "adhesive lap-shear and peel-representative coupons",
+    "insert pull-out test",
+    "insert torsional-slip test",
+    "member bending test",
+    "member torsion test",
+    "joint-cycle and acoustic test",
+    "electrical isolation and capacitive-sensing test",
+    "service-access rehearsal",
+    "guarding and contact-comfort review"
+  ],
+  "release_blockers": [
+    "validated forearm dimensions",
+    "selected carbon product and datasheet",
+    "selected insert alloy",
+    "selected adhesive system",
+    "resolved elbow and wrist kinematics",
+    "defined design loads and safety factors",
+    "passed destructive coupon tests",
+    "passed subcomponent fatigue test"
+  ]
+}

--- a/PROJECTS/T56_CARBON/components/system_architecture.md
+++ b/PROJECTS/T56_CARBON/components/system_architecture.md
@@ -1,0 +1,136 @@
+# T-5.6 Carbon System Architecture
+
+Status: `CONCEPT_SCAFFOLD`
+
+This document translates the T-5.6 visual and functional direction into a PHY-compatible mechanical architecture. It is topology guidance, not a dimensional fabrication drawing.
+
+## 1. Primary load path
+
+The body uses a continuous central load path:
+
+`skull and neck -> segmented spine -> sacral load bridge -> bilateral hip cartridges -> femoral members -> knees -> lower-leg members -> compliant feet`
+
+The shoulder girdle branches from the upper thoracic spine into clavicle/scapula structures and replaceable shoulder cartridges.
+
+## 2. Long-member language
+
+Long bones use open or closed carbon-composite truss members rather than solid replicas of biological bones.
+
+Preferred features:
+
+- paired longitudinal rails
+- transverse or diagonal webs
+- closed reinforced zones near inserts
+- protected central service cavity
+- replaceable nonstructural access covers
+- local strain, temperature, and impact sensing
+
+Commercial structural tube stock may be used in early prototypes when it lowers fabrication risk. Custom open trusses require validated laminate design, tooling, and destructive testing.
+
+## 3. Torso layers
+
+The torso is divided into five serviceable layers:
+
+1. spine and pelvic load structure
+2. shoulder, rib, and sternum frame
+3. actuator, power, and electronics cradle
+4. removable composite service shells
+5. compliant fascia, volume, and tactile skin
+
+Cosmetic panels are not primary load-bearing members unless explicitly analyzed and validated as such.
+
+## 4. Pelvis
+
+The pelvis consists of:
+
+- central sacral load bridge
+- left and right iliac composite shells
+- independent hip cartridges
+- compliant tensile stabilization network
+- guarded cable and tendon routing
+
+The iliac shells distribute torso loads and provide attachment structure. The hip cartridges carry bearing surfaces, shafts, actuator interfaces, and replaceable wear components. The tensile network supports controlled compliance and sensing without becoming the sole load path.
+
+## 5. Legs
+
+### Femur
+
+A paired-rail carbon member carries bending and torsion between hip and knee cartridges. The proximal and distal ends transition into reinforced closed sections around bonded inserts.
+
+### Knee
+
+The knee is an enclosed replaceable cartridge with explicit hard stops, position sensing, load sensing, and pinch-point guarding. Carbon members do not serve directly as bearing races.
+
+### Lower leg
+
+The tibial structure is the primary load path. A lighter fibular member contributes torsional stability, routing, fascia attachment, and protective geometry. Actuation and damping elements may occupy the protected cavity between rails.
+
+## 6. Feet
+
+The domestic foot uses:
+
+- carbon metatarsal spring structure
+- compliant heel element
+- articulated toe beam
+- pressure and shear sensing
+- replaceable soft sole
+- hidden lateral width sufficient for indoor stability
+
+The exterior may remain visually narrow, but the functional sole must support standing, turning, uneven floors, and accidental close contact.
+
+## 7. Arms and hands
+
+The upper arm and forearm use the same reinforced truss doctrine as the legs. The hand uses:
+
+- rigid composite metacarpal frame
+- modular finger linkages
+- tendon tubes through the palm
+- proximal actuators located in the forearm when practical
+- local tactile and position sensing
+- removable dorsal service cover
+
+Low distal mass is prioritized over hiding every mechanism inside the fingers.
+
+## 8. Spine and neck
+
+The spine uses segmented composite vertebral bodies around replaceable joint cartridges. The centerline carries protected power, data, sensing, and thermal-routing paths. The neck requires redundant motion limits and cable-strain control.
+
+## 9. Artificial fascia
+
+The artificial fascia is a tensioned technical-textile network between skeleton and outer body. It provides:
+
+- vibration damping
+- distributed skin support
+- continuity across joints
+- cable and sensor attachment
+- controllable body volume
+- load spreading for soft contact
+
+Fascia is replaceable and must not conceal inaccessible structural fasteners or trap heat around power electronics.
+
+## 10. Electrical doctrine
+
+Carbon conductivity is treated explicitly.
+
+- structural members are segmented into intentional electrical zones
+- actuator power is isolated from tactile sensing
+- metal inserts are bonded to defined electrical potential only by design
+- galvanic isolation is required at vulnerable dissimilar-metal interfaces
+- frame continuity, leakage, grounding, and capacitive behavior are tested before skin installation
+
+## 11. Domestic adaptation rules
+
+Compared with aggressive visual concept references, T-5.6 uses:
+
+- quieter and more enclosed joints
+- narrower shoulder packaging
+- broader hidden foot support
+- compliant pelvic and torso layers
+- guarded fingers, wrists, knees, and ankles
+- rounded service covers
+- low-temperature exterior surfaces
+- accessible maintenance panels
+
+## 12. Hard stop
+
+No visual reference supplies dimensions, laminate schedules, material strengths, joint limits, actuator sizing, or safety factors. Those values remain unresolved until supported by traceable references, calculations, and physical testing.

--- a/PROJECTS/T56_CARBON/materials/material_architecture.json
+++ b/PROJECTS/T56_CARBON/materials/material_architecture.json
@@ -1,0 +1,105 @@
+{
+  "project": "T56_CARBON",
+  "status": "scaffold_unvalidated",
+  "material_families": {
+    "carbon_epoxy_primary_members": {
+      "use": [
+        "long-bone truss rails",
+        "torso shells",
+        "pelvic shells",
+        "rib and clavicle members",
+        "hand and foot structural plates"
+      ],
+      "required_properties": [
+        "fiber architecture",
+        "laminate schedule",
+        "density_kg_m3",
+        "longitudinal_modulus_GPa",
+        "transverse_modulus_GPa",
+        "shear_modulus_GPa",
+        "tensile_strength_MPa",
+        "compressive_strength_MPa",
+        "interlaminar_shear_strength_MPa",
+        "glass_transition_temperature_C"
+      ],
+      "rules": [
+        "No fabrication release without traceable datasheet or tested coupon values.",
+        "Fiber orientation must follow the local load path.",
+        "Drilled interfaces require local laminate reinforcement and bearing validation.",
+        "Conductive dust controls are mandatory for machining."
+      ]
+    },
+    "metal_joint_cartridges": {
+      "use": [
+        "bearing races",
+        "threaded interfaces",
+        "actuator mounts",
+        "shaft supports",
+        "replaceable wear surfaces"
+      ],
+      "candidate_families": [
+        "titanium alloy",
+        "corrosion-resistant steel",
+        "other validated corrosion-resistant insert alloy"
+      ],
+      "rules": [
+        "Metal choice remains unresolved until load, corrosion, mass, and manufacturing studies are complete.",
+        "Direct carbon-to-aluminum contact is prohibited without validated dielectric isolation.",
+        "All cartridges must be replaceable without cutting primary composite members."
+      ]
+    },
+    "dielectric_isolation": {
+      "use": [
+        "carbon-metal galvanic isolation",
+        "sensor-zone segmentation",
+        "power-system isolation"
+      ],
+      "candidate_families": [
+        "glass-fiber composite interlayer",
+        "validated polymer sleeve",
+        "sealed dielectric coating system"
+      ]
+    },
+    "structural_adhesive": {
+      "use": [
+        "bonded internal inserts",
+        "secondary composite assembly",
+        "local load-spreading doublers"
+      ],
+      "required_properties": [
+        "substrate compatibility",
+        "lap shear strength",
+        "peel resistance",
+        "service temperature range",
+        "cure schedule",
+        "humidity resistance",
+        "fatigue behavior"
+      ],
+      "rules": [
+        "No adhesive is selected by brand reputation alone.",
+        "Production bond geometry must be represented by destructive test coupons.",
+        "Bonded inserts require keyed geometry and secondary mechanical capture."
+      ]
+    },
+    "artificial_fascia": {
+      "use": [
+        "tension distribution",
+        "vibration damping",
+        "outer-body support",
+        "sensor and cable attachment",
+        "joint-area continuity"
+      ],
+      "candidate_families": [
+        "high-strength braided fiber",
+        "elastic technical textile",
+        "hybrid compliant mesh"
+      ]
+    }
+  },
+  "global_rules": [
+    "No raw bolt or washer may concentrate load directly into unreinforced laminate.",
+    "Every concentrated load enters through a validated insert, doubler, or cartridge.",
+    "Electrical conductivity of carbon must be treated as an explicit system property.",
+    "Unknown material constants remain null until referenced or tested."
+  ]
+}

--- a/PROJECTS/T56_CARBON/profiles/t56_domestic_frame.json
+++ b/PROJECTS/T56_CARBON/profiles/t56_domestic_frame.json
@@ -1,0 +1,48 @@
+{
+  "profile_id": "t56_domestic_frame",
+  "project": "T56_CARBON",
+  "status": "scaffold_requires_anthropometric_validation",
+  "description": "Project-local proportion and behavior profile for the T-5.6 domestic carbon-composite armature.",
+  "height_mm": 1676.4,
+  "arm_span_mm": 1676.4,
+  "height_code": "T-5.6",
+  "lineage": "mature domestic evolution of T-5.5(5)",
+  "pose_baseline": "neutral_anatomical_t_pose",
+  "design_mode": "domestic_close_proximity",
+  "proportion_targets": {
+    "head_height_mm": null,
+    "biacromial_shoulder_breadth_mm": null,
+    "pelvis_breadth_mm": null,
+    "ribcage_max_width_mm": null,
+    "humerus_length_mm": null,
+    "radius_length_mm": null,
+    "ulna_length_mm": null,
+    "hand_total_length_mm": null,
+    "femur_length_mm": null,
+    "tibia_length_mm": null,
+    "fibula_length_mm": null,
+    "foot_total_length_mm": null
+  },
+  "proportion_policy": {
+    "adult_capable_anatomy": true,
+    "avoid_exaggerated_display_anatomy": true,
+    "bilateral_symmetry_initially": true,
+    "allow_calibrated_asymmetry_after_fit_testing": true,
+    "preserve_domestic_clearance_envelopes": true
+  },
+  "domestic_performance_targets": {
+    "quiet_motion_priority": "high",
+    "close_contact_compliance_priority": "high",
+    "reclining_posture_priority": "high",
+    "serviceability_priority": "high",
+    "tactile_sensor_density_priority": "high",
+    "pinch_point_guarding_priority": "high",
+    "thermal_surface_stability_priority": "high"
+  },
+  "validation_rules": [
+    "Height and arm span are project decisions.",
+    "All remaining anatomical dimensions require traceable anthropometric references or measured fit targets.",
+    "Visual concept art may guide topology and service architecture but may not supply fabrication dimensions.",
+    "Joint-center locations must be resolved through project joint modules before fabrication release."
+  ]
+}

--- a/PROJECTS/T56_CARBON/references/visual_reference_decomposition.md
+++ b/PROJECTS/T56_CARBON/references/visual_reference_decomposition.md
@@ -1,0 +1,58 @@
+# T-5.6 Visual Reference Decomposition
+
+Status: `NON-DIMENSIONAL_DESIGN_REFERENCE`
+
+The user supplied a series of external humanoid-skeleton concept images as visual references. This document extracts topology, serviceability, and packaging lessons only. It does not reproduce the images and does not treat them as a source of dimensions, material properties, joint limits, or fabrication authority.
+
+## Useful design language
+
+### Open long-bone structures
+
+The references favor long members built as open rails and webs rather than solid biological replicas. T-5.6 adopts this as a composite truss language where it improves stiffness, cable routing, inspection, and mass distribution.
+
+### Nested joint cartridges
+
+Shoulders, hips, elbows, knees, wrists, and ankles appear as discrete modules between long members. T-5.6 converts this into replaceable metallic joint cartridges with bearings, hard stops, sensing, and service access.
+
+### Layered torso
+
+The torso imagery suggests a central load-bearing core surrounded by removable shells and lattice structures. T-5.6 separates spine, rib/shoulder frame, actuator cradle, service panels, fascia, and skin into distinct maintainable layers.
+
+### Pelvic bridge and tensile support
+
+The pelvic imagery suggests independent lateral shells around a central bridge, with tension structures connecting spine, pelvis, and hip regions. T-5.6 interprets this as a sacral load bridge, bilateral iliac shells, independent hip cartridges, and a non-primary tensile stabilization network.
+
+### Tendon-driven hands
+
+The hand references show light distal finger structures and visible routing through the palm. T-5.6 prioritizes low distal mass, modular finger links, tendon tubes, proximal forearm actuation where practical, and a removable dorsal service cover.
+
+### Artificial musculature and fascia
+
+The translucent mesh imagery suggests a continuous tension layer over the skeleton. T-5.6 formalizes this as replaceable technical-textile fascia for damping, body-volume support, cable attachment, and continuity across joints.
+
+## Required domestic departures
+
+The visual references are optimized for dramatic mechanical exposure. T-5.6 changes that language for close indoor operation:
+
+- exposed mechanisms become guarded or softly covered
+- sharp truss corners receive rounded service shells
+- shoulder packaging narrows
+- feet gain broader hidden support and soft soles
+- joint acoustics and thermal surfaces become explicit acceptance criteria
+- wrist, finger, knee, and ankle pinch zones are guarded
+- maintenance access remains possible without removing the entire outer body
+
+## Rejected interpretations
+
+The following are explicitly rejected:
+
+- scaling pixel measurements into fabrication dimensions
+- copying proprietary surface geometry
+- assuming visible parts are structurally plausible
+- inferring actuator torque or joint range from rendered pose
+- treating cosmetic shells as proven load-bearing members
+- reproducing logos, titles, or identifying marks from the source images
+
+## Design sentence
+
+> Open carbon bones, enclosed metal joints, tendon hands, central spine, tensioned fascia, soft domestic skin.

--- a/PROJECTS/T56_CARBON/tests/coupon_test_plan.md
+++ b/PROJECTS/T56_CARBON/tests/coupon_test_plan.md
@@ -1,0 +1,109 @@
+# T-5.6 Composite Coupon Test Plan
+
+Status: `DRAFT_TEST_ARCHITECTURE`
+
+This plan defines the minimum evidence required before any T-5.6 composite member, bonded insert, or joint interface can be marked fabrication-ready.
+
+## Test families
+
+### 1. Material witness coupons
+
+Produce witness coupons from the same material batch, layup, cure process, tooling, and post-processing used for the intended component.
+
+Record:
+
+- material lot and supplier
+- fiber architecture
+- nominal and measured thickness
+- resin system
+- cure schedule
+- fiber orientation
+- voids, porosity, and visible defects
+- edge preparation and machining method
+- environmental conditioning
+
+### 2. Bond-process coupons
+
+Represent the actual production surface preparation, adhesive thickness, cure, bond length, insert material, and dielectric interlayer.
+
+Required modes:
+
+- lap-shear representative test
+- peel-sensitive representative test
+- humidity-conditioned test
+- elevated-temperature test within planned service range
+- cure-process repeatability check
+
+### 3. Bonded-insert coupons
+
+Use the same tube or truss-end geometry intended for the forearm demonstrator.
+
+Required modes:
+
+- axial pull-out
+- axial push-through
+- torsional slip
+- cyclic torsion
+- combined bending and axial load
+- post-impact residual-strength check
+
+The insert must include keyed anti-rotation geometry and secondary mechanical capture.
+
+### 4. Bearing and fastener coupons
+
+Validate:
+
+- bearing stress around reinforced holes
+- clamp-load sensitivity
+- edge distance
+- washer or flange load spreading
+- bolt clearance
+- repeated assembly and disassembly
+- local delamination after cycling
+
+No result from unreinforced flat laminate may be generalized to a reinforced production joint without justification.
+
+### 5. Electrical and environmental tests
+
+Measure:
+
+- resistance along and across the member
+- continuity between carbon and metal inserts
+- dielectric isolation resistance
+- capacitive coupling between sensor zones
+- leakage under humidity
+- thermal behavior near actuators and power conductors
+- galvanic-isolation integrity after conditioning
+
+### 6. Dust and process controls
+
+Before machining carbon composite, document:
+
+- local extraction
+- conductive-dust containment
+- respiratory and skin protection
+- tool and electronics isolation
+- cleanup method
+- waste handling
+
+Dry sanding or cutting in an occupied electronics area is not an accepted process.
+
+## Forearm release gates
+
+The left forearm demonstrator remains blocked until:
+
+1. dimensions and design loads are defined;
+2. material and adhesive systems are selected;
+3. witness and bond coupons pass;
+4. insert pull-out and torsion margins meet the project safety factor;
+5. forearm-member bending and torsion tests pass;
+6. elbow and wrist cartridges pass cycle and acoustic tests;
+7. electrical segmentation and touch sensing remain stable under load;
+8. service covers and fascia mounts survive repeated maintenance cycles;
+9. all failures and unknowns are recorded in a project validation report.
+
+## Data policy
+
+Raw measurements, test setup, photographs, failure modes, and rejected specimens are part of the engineering record. Passing summaries without raw evidence are insufficient.
+
+Unknowns are reported; they are not backfilled from concept art or generic composite-property tables.


### PR DESCRIPTION
## What changed

Creates a new `PROJECTS/T56_CARBON/` overlay for the 1676.4 mm T-5.6 domestic humanoid frame.

The scaffold adds:

- project charter and design doctrine
- height-coded domestic frame profile
- composite, metal, adhesive, dielectric, and fascia material architecture
- left forearm systems demonstrator
- whole-body carbon-frame architecture
- destructive coupon and bonded-insert test plan
- non-dimensional decomposition of the user-provided visual references
- registration in `PROJECTS/README.md`

## Why

PHY already separates universal skeleton truth from project-specific embodiments. T-5.6 needs its own overlay rather than modifying REDWOOD or contaminating the canonical skeleton with carbon-specific assumptions.

## Engineering boundary

This PR intentionally marks the project as **not fabrication-ready**. Dimensions beyond the fixed 1676.4 mm height/arm-span target remain unresolved. Laminate schedules, material constants, adhesives, insert geometry, design loads, safety factors, joint limits, and actuator sizing require traceable references and destructive testing.

Visual concept art is treated only as topology and serviceability inspiration; it is not used as dimensional or material authority.

## Validation performed

- confirmed all new files are present on `agent/t56-carbon-scaffold`
- verified the project charter renders from the branch
- preserved universal PHY core files unchanged

## Next work

1. define traceable T-5.6 anthropometric targets
2. select candidate carbon products, insert alloy, dielectric system, and adhesive
3. resolve elbow/wrist kinematics and forearm design loads
4. generate witness, bond, and insert coupon drawings
5. build the left forearm validation packet
